### PR TITLE
Fix Pardiso bug

### DIFF
--- a/Rules.make
+++ b/Rules.make
@@ -75,8 +75,8 @@ export NBDYDIM = 100000
 ##############################################
 
 #FORTRAN_COMPILER = GNU_G77
-#FORTRAN_COMPILER = GNU_GFORTRAN
-FORTRAN_COMPILER = INTEL
+FORTRAN_COMPILER = GNU_GFORTRAN
+#FORTRAN_COMPILER = INTEL
 #FORTRAN_COMPILER = PORTLAND
 #FORTRAN_COMPILER = IBM
 
@@ -134,8 +134,8 @@ PARALLEL=false
 ##############################################
 
 #SOLVER=GAUSS
-#SOLVER=SPARSKIT
-SOLVER=PARDISO
+SOLVER=SPARSKIT
+#SOLVER=PARDISO
 
 ##############################################
 # NetCDF library

--- a/Rules.make
+++ b/Rules.make
@@ -75,8 +75,8 @@ export NBDYDIM = 100000
 ##############################################
 
 #FORTRAN_COMPILER = GNU_G77
-FORTRAN_COMPILER = GNU_GFORTRAN
-#FORTRAN_COMPILER = INTEL
+#FORTRAN_COMPILER = GNU_GFORTRAN
+FORTRAN_COMPILER = INTEL
 #FORTRAN_COMPILER = PORTLAND
 #FORTRAN_COMPILER = IBM
 
@@ -134,8 +134,8 @@ PARALLEL=false
 ##############################################
 
 #SOLVER=GAUSS
-SOLVER=SPARSKIT
-#SOLVER=PARDISO
+#SOLVER=SPARSKIT
+SOLVER=PARDISO
 
 ##############################################
 # NetCDF library

--- a/fem3d/Makefile
+++ b/fem3d/Makefile
@@ -722,111 +722,113 @@ last:
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 ../femlib/mod/para_aqua.mod: aquabc_II_apara.o
-aquabc_II_fem_interface.o: ../femlib/mod/basin.mod \
-		../femlib/mod/para_aqua.mod \
-		../femlib/mod/aquabc_II_sed_ini.mod mkonst.h \
+aquabc_II_fem_interface.o: aquabc_II.h \
 		../femlib/mod/mod_diff_visc_fric.mod param.h \
-		aquabc_II_aout.h femtime.h \
-		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
-		aquabc_II.h 
+		../femlib/mod/basin.mod mkonst.h \
+		../femlib/mod/aquabc_II_sed_ini.mod \
+		../femlib/mod/levels.mod aquabc_II_aout.h \
+		femtime.h ../femlib/mod/para_aqua.mod \
+		../femlib/mod/evgeom.mod 
 aquabc_II_util.o: param.h
-atoxi3d.o: param.h mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/levels.mod ../femlib/mod/basin.mod 
-basbathy.o: param.h simul.h ../femlib/mod/evgeom.mod pkonst.h \
-		../femlib/mod/basin.mod ../femlib/mod/grd.mod \
+atoxi3d.o: ../femlib/mod/basin.mod mkonst.h \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_diff_visc_fric.mod param.h 
+basbathy.o: simul.h param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/grd.mod pkonst.h \
+		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod 
+basbox.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom.mod param.h \
 		../femlib/mod/mod_depth.mod 
-basbox.o: ../femlib/mod/mod_depth.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/basin.mod param.h \
-		../femlib/mod/evgeom.mod 
-baschk.o: pkonst.h ../femlib/mod/basin.mod param.h \
-		../femlib/mod/evgeom.mod simul.h 
-bascomp.o: ../femlib/mod/basin.mod param.h \
-		../femlib/mod/evgeom.mod 
-bashsigma.o: param.h ../femlib/mod/evgeom.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod 
-basinf.o: param.h ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_depth.mod \
+baschk.o: param.h simul.h pkonst.h ../femlib/mod/evgeom.mod \
 		../femlib/mod/basin.mod 
+bascomp.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/evgeom.mod 
+bashsigma.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		param.h ../femlib/mod/mod_depth.mod 
+basinf.o: ../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h 
 basproj.o: param.h ../femlib/mod/basin.mod
 basres.o: ../femlib/mod/basin.mod param.h
-bastreat.o: ../femlib/mod/grd.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/evgeom.mod param.h 
-baswork.o: ../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+bastreat.o: ../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
 		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/evgeom.mod 
-bdist.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod 
-bio3d.o: ../femlib/mod/mod_diff_visc_fric.mod mkonst.h param.h \
-		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
-bio3d_util.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/levels.mod donata.h 
+		../femlib/mod/grd.mod ../femlib/mod/mod_geom.mod 
+baswork.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom.mod param.h \
+		../femlib/mod/mod_depth.mod 
+bdist.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		param.h 
+bio3d.o: ../femlib/mod/basin.mod mkonst.h param.h \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_diff_visc_fric.mod 
+bio3d_util.o: param.h donata.h ../femlib/mod/levels.mod \
+		../femlib/mod/basin.mod 
 debug.o: debug_aux1.h
 ../femlib/mod/elabutil.mod: elabutil.o
-elabutil.o: param.h ../femlib/mod/clo.mod ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod 
+elabutil.o: ../femlib/mod/basin.mod ../femlib/mod/clo.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod param.h 
 eosinf.o: param.h
 etsinf.o: param.h ../femlib/mod/ets.mod
-extelab1.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
-		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/clo.mod ../femlib/mod/elabutil.mod 
+extelab1.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/levels.mod ../femlib/mod/clo.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/elabutil.mod 
 femelab.o: ../femlib/mod/clo.mod
 feminf.o: ../femlib/mod/clo.mod
 filetype.o: ../femlib/mod/clo.mod
 flxinf.o: param.h
-gotm3d.o: gotmturb.i debug_aux1.h
+gotm3d.o: debug_aux1.h gotmturb.i
 grdutil.o: ../femlib/mod/grd.mod ../femlib/mod/basin.mod
-intp.o: ../femlib/mod/basin.mod ../femlib/mod/mod_hydro.mod \
-		param.h 
-lagrange_back.o: ../femlib/mod/mod_hydro.mod lagrange.h param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_hydro_print.mod 
-lagrange_cont.o: lagrange.h param.h ../femlib/mod/mod_geom.mod \
+intp.o: param.h ../femlib/mod/mod_hydro.mod \
 		../femlib/mod/basin.mod 
-lagrange_decay.o: param.h lagrange.h femtime.h
-lagrange_dif.o: param.h lagrange.h femtime.h
-lagrange_flux.o: ../femlib/mod/mod_layer_thickness.mod \
+lagrange_back.o: ../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_depth.mod lagrange.h \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		femtime.h lagrange.h param.h \
-		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod 
-lagrange_init.o: ../femlib/mod/basin.mod lagrange.h param.h
-lagrange_inout.o: femtime.h lagrange.h param.h \
-		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_print.mod 
+lagrange_cont.o: ../femlib/mod/mod_geom.mod lagrange.h param.h \
+		../femlib/mod/basin.mod 
+lagrange_decay.o: lagrange.h param.h femtime.h
+lagrange_dif.o: femtime.h lagrange.h param.h
+lagrange_flux.o: ../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod param.h lagrange.h \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/evgeom.mod femtime.h \
+		../femlib/mod/levels.mod 
+lagrange_init.o: ../femlib/mod/basin.mod param.h lagrange.h
+lagrange_inout.o: ../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/lgr_sedim_module.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod 
-lagrange_larve.o: param.h lagrange.h
+		../femlib/mod/basin.mod param.h lagrange.h \
+		femtime.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/levels.mod 
+lagrange_larve.o: lagrange.h param.h
 lagrange_main.o: ../femlib/mod/basin.mod \
 		../femlib/mod/lgr_sedim_module.mod femtime.h \
 		param.h lagrange.h 
-lagrange_oil.o: femtime.h lagrange.h param.h \
+lagrange_oil.o: param.h lagrange.h femtime.h \
 		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod 
 ../femlib/mod/lgr_sedim_module.mod: lagrange_sedim.o
-lagrange_sedim.o: ../femlib/mod/levels.mod lagrange.h param.h
-lagrange_track.o: lagrange.h param.h ../femlib/mod/mod_geom.mod \
+lagrange_sedim.o: lagrange.h param.h ../femlib/mod/levels.mod
+lagrange_track.o: param.h lagrange.h ../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod 
+lagrange_util.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/evgeom.mod 
+lagrange_util_tr.o: ../femlib/mod/basin.mod param.h
+lagrange_vertical.o: ../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_depth.mod lagrange.h \
 		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_vel.mod \
 		../femlib/mod/levels.mod 
-lagrange_util.o: ../femlib/mod/evgeom.mod param.h \
-		../femlib/mod/basin.mod 
-lagrange_util_tr.o: param.h ../femlib/mod/basin.mod
-lagrange_vertical.o: ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod lagrange.h param.h \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod 
-lgrelab.o: ../femlib/mod/basin.mod ../femlib/mod/mod_depth.mod \
-		param.h 
-lgrinf.o: param.h
-loading.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod 
-map_influence.o: param.h ../femlib/mod/basin.mod \
+lgrelab.o: ../femlib/mod/basin.mod param.h \
 		../femlib/mod/mod_depth.mod 
+lgrinf.o: param.h
+loading.o: ../femlib/mod/levels.mod param.h \
+		../femlib/mod/basin.mod 
+map_influence.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h 
 ../femlib/mod/mod_area.mod: mod_area.o
 ../femlib/mod/mod_bclfix.mod: mod_bclfix.o
 ../femlib/mod/mod_bnd.mod: mod_bnd.o
@@ -861,556 +863,565 @@ mod_subset.o: ../femlib/mod/basin.mod
 ../femlib/mod/mod_turbulence.mod: mod_turbulence.o
 ../femlib/mod/mod_tvd.mod: mod_tvd.o
 ../femlib/mod/mod_waves.mod: mod_waves.o
-netcdf.o: netcdf.h netcdf.inc param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
-netcdf_util.o: ../femlib/mod/basin.mod param.h
-new36.o: close.h ../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod mkonst.h \
-		../femlib/mod/mod_diff_visc_fric.mod param.h \
-		femtime.h 
-new3di.o: ../femlib/mod/evgeom.mod ../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_tides.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_depth.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_nudging.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_waves.mod mkonst.h \
-		../femlib/mod/mod_diff_visc_fric.mod param.h \
-		femtime.h 
-newbcl.o: ../femlib/mod/mod_diff_visc_fric.mod mkonst.h femtime.h \
-		param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_ts.mod pkonst.h \
+netcdf.o: ../femlib/mod/basin.mod ../femlib/mod/mod_depth.mod \
+		param.h netcdf.h netcdf.inc \
 		../femlib/mod/levels.mod 
-newchao.o: ../femlib/mod/levels.mod ../femlib/mod/basin.mod \
-		femtime.h param.h ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod 
-newchk.o: ../femlib/mod/mod_meteo.mod \
+netcdf_util.o: ../femlib/mod/basin.mod param.h
+new36.o: mkonst.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro_print.mod close.h param.h \
+		../femlib/mod/mod_bound_dynamic.mod femtime.h 
+new3di.o: ../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_nudging.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro.mod femtime.h \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_roughness.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_ts.mod param.h femtime.h \
-		mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_bound_dynamic.mod 
-newcon.o: mkonst.h femtime.h param.h ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_layer_thickness.mod 
-newcon_omp.o: ../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro.mod \
 		../femlib/mod/levels.mod \
+		../femlib/mod/mod_layer_thickness.mod mkonst.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/mod_waves.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_internal.mod pkonst.h \
+		../femlib/mod/mod_tides.mod 
+newbcl.o: ../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod param.h mkonst.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod pkonst.h \
+		../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
+		femtime.h 
+newchao.o: ../femlib/mod/levels.mod ../femlib/mod/mod_hydro.mod \
+		param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_baro.mod femtime.h 
+newchk.o: ../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro_baro.mod femtime.h \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod mkonst.h param.h \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_internal.mod 
+newcon.o: ../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_bound_geom.mod param.h \
+		../femlib/mod/mod_diff_aux.mod mkonst.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
+		femtime.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro_vel.mod 
+newcon_omp.o: ../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
 		../femlib/mod/mod_depth.mod \
 		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_subset.mod \
 		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_bound_dynamic.mod 
-newconz.o: ../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_conz.mod ../femlib/mod/basin.mod \
-		mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
-		param.h femtime.h 
-newcra.o: ../femlib/mod/mod_bnd_aux.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod param.h femtime.h mkonst.h \
-		pkonst.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod 
-newexpl.o: ../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod \
-		pkonst.h ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom.mod \
 		../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_internal.mod param.h 
-newfix.o: ../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/levels.mod param.h femtime.h \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_bclfix.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod 
-newini.o: mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_internal.mod param.h \
 		../femlib/mod/basin.mod \
+		../femlib/mod/mod_diff_aux.mod 
+newconz.o: mkonst.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_diff_visc_fric.mod param.h \
+		../femlib/mod/mod_ts.mod femtime.h \
+		../femlib/mod/levels.mod 
+newcra.o: ../femlib/mod/basin.mod mkonst.h \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/mod_bnd_aux.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/levels.mod pkonst.h 
+		../femlib/mod/mod_hydro_baro.mod femtime.h \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_bound_dynamic.mod pkonst.h 
+newexpl.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_ts.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/levels.mod pkonst.h \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_geom_dynamic.mod 
+newfix.o: femtime.h ../femlib/mod/mod_bclfix.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_hydro.mod 
+newini.o: ../femlib/mod/mod_internal.mod ../femlib/mod/levels.mod \
+		pkonst.h ../femlib/mod/mod_roughness.mod param.h \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro.mod mkonst.h \
+		../femlib/mod/basin.mod 
 ../femlib/mod/levels.mod: newlevels.o
 ../femlib/mod/mod_nudge.mod: newnudge.o
-newnudge.o: ../femlib/mod/basin.mod ../femlib/mod/mod_nudging.mod \
-		../femlib/mod/mod_internal.mod femtime.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/intp_fem_file.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_layer_thickness.mod 
-newrog.o: param.h ../femlib/mod/basin.mod
-newstab.o: ../femlib/mod/basin.mod ../femlib/mod/levels.mod stab.h \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_conz.mod param.h 
-newtra.o: ../femlib/mod/mod_depth.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod \
+newnudge.o: ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_nudging.mod \
 		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/levels.mod femtime.h \
+		../femlib/mod/intp_fem_file.mod 
+newrog.o: ../femlib/mod/basin.mod param.h
+newstab.o: ../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/levels.mod param.h stab.h \
+		../femlib/mod/basin.mod 
+newtra.o: ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
 		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod param.h 
-newtvd.o: param.h ../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_tvd.mod ../femlib/mod/levels.mod 
-nos2nc.o: ../femlib/mod/levels.mod ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod param.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro.mod 
-noselab1.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
-		../femlib/mod/levels.mod ../femlib/mod/clo.mod \
-		../femlib/mod/evgeom.mod param.h \
-		../femlib/mod/elabutil.mod 
-nosextr_nodes.o: ../femlib/mod/levels.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/evgeom.mod 
-nosresidence.o: ../femlib/mod/evgeom.mod param.h \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_depth.mod 
+newtvd.o: ../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/basin.mod ../femlib/mod/mod_tvd.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_hydro_print.mod param.h 
+nos2nc.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_depth.mod 
+noselab1.o: ../femlib/mod/levels.mod ../femlib/mod/clo.mod param.h \
+		../femlib/mod/elabutil.mod \
 		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
-optintp.o: param.h ../femlib/mod/clo.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod 
-ous2nc.o: param.h ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod 
-ouselab1.o: ../femlib/mod/elabutil.mod ../femlib/mod/clo.mod \
-		../femlib/mod/basin.mod \
+		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
+nosextr_nodes.o: ../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
+nosresidence.o: ../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/levels.mod 
+optintp.o: ../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/clo.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/basin.mod 
+ous2nc.o: ../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/levels.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod 
+ouselab1.o: ../femlib/mod/mod_hydro_baro.mod \
 		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/elabutil.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro.mod ../femlib/mod/clo.mod \
 		../femlib/mod/mod_depth.mod 
 ousutil.o: ../femlib/mod/evgeom.mod
 readext.o: param.h ../femlib/mod/basin.mod
-scal_intp.o: ../femlib/mod/basin.mod param.h \
+scal_intp.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/evgeom.mod 
-scalintp.o: simul.h ../femlib/mod/evgeom.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod pkonst.h 
-sedi3d.o: param.h ../femlib/mod/mod_diff_visc_fric.mod \
+scalintp.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		pkonst.h simul.h ../femlib/mod/mod_depth.mod \
+		param.h 
+sedi3d.o: ../femlib/mod/mod_roughness.mod ../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/evgeom.mod sed_param.h \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_waves.mod \
 		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod sed_param.h 
-shyelab.o: ../femlib/mod/elabutil.mod ../femlib/mod/clo.mod
-shyfem.o: mkonst.h param.h ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_conz.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bndo.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_nohyd.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_nudging.mod \
-		../femlib/mod/mod_tides.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/intp_fem_file.mod \
-		../femlib/mod/mod_bclfix.mod \
-		../femlib/mod/mod_diff_visc_fric.mod femtime.h \
-		../femlib/mod/mod_bnd.mod \
-		../femlib/mod/mod_bnd_aux.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/mod_geom.mod 
+shyelab.o: ../femlib/mod/clo.mod ../femlib/mod/elabutil.mod
+shyfem.o: ../femlib/mod/levels.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_tvd.mod \
-		../femlib/mod/mod_waves.mod \
-		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_roughness.mod femtime.h \
+		../femlib/mod/mod_bnd.mod \
 		../femlib/mod/mod_turbulence.mod \
-		../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_diff_aux.mod \
+		../femlib/mod/mod_bnd_aux.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_subset.mod \
+		../femlib/mod/mod_tides.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_subset.mod param.h mkonst.h \
+		../femlib/mod/mod_tvd.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_sinking.mod \
 		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/mod_bclfix.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/intp_fem_file.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_nohyd.mod \
+		../femlib/mod/mod_nudging.mod \
+		../femlib/mod/mod_meteo.mod pkonst.h \
+		../femlib/mod/mod_bndo.mod \
 		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_fluidmud.mod pkonst.h \
-		../femlib/mod/levels.mod 
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_diff_aux.mod \
+		../femlib/mod/mod_waves.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/mod_layer_thickness.mod 
 shypre.o: ../femlib/mod/clo.mod param.h ../femlib/mod/basin.mod
 sigmautil.o: sigma.h
-simsys_lp.o: ../femlib/mod/mod_system.mod param.h \
-		../femlib/mod/basin.mod 
-simsys_pard.o: param.h ../femlib/mod/mod_system.mod \
-		../femlib/mod/basin.mod 
-simsys_spk.o: ../femlib/mod/basin.mod ../femlib/mod/mod_system.mod \
+simsys_lp.o: ../femlib/mod/mod_system.mod ../femlib/mod/basin.mod \
+		param.h 
+simsys_pard.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_system.mod param.h 
+simsys_spk.o: ../femlib/mod/mod_system.mod ../femlib/mod/basin.mod \
 		param.h 
 splitets.o: param.h
 splitflx.o: param.h
 subapn.o: ../femlib/mod/basin.mod
 ../femlib/mod/basin.mod: subbas.o
 subbas.o: param.h
-subbfm.o: bfm_common.h ../femlib/mod/mod_diff_visc_fric.mod \
-		param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_sinking.mod \
+subbfm.o: pkonst.h ../femlib/mod/levels.mod \
 		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod pkonst.h 
-subbnd.o: bound_names.h param.h ../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_sinking.mod bfm_common.h 
+subbnd.o: ../femlib/mod/mod_bound_geom.mod param.h bound_names.h \
 		../femlib/mod/mod_bnd.mod 
-subbndo.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/mod_bndo.mod \
-		param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/levels.mod 
-subbnds.o: ../femlib/mod/intp_fem_file.mod
-subboxa.o: ../femlib/mod/mod_ts.mod ../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_conz.mod \
+subbndo.o: ../femlib/mod/basin.mod ../femlib/mod/mod_bndo.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom_dynamic.mod param.h \
-		subboxa.h femtime.h \
-		../femlib/mod/mod_diff_visc_fric.mod \
 		../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod modules.h 
-../femlib/mod/clo.mod: subclo.o
-subcon1.o: ../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod simul.h mkonst.h femtime.h \
-		param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod 
-subcoo.o: param.h ../femlib/mod/mod_system.mod
-subcoord.o: coords_utm.h coords_cpp.h coords_gb.h coords.h
-subcst.o: modules.h mkonst.h param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bnd.mod pkonst.h 
-subcus.o: ../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_area.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_depth.mod param.h femtime.h \
+		../femlib/mod/mod_geom.mod param.h \
+		../femlib/mod/mod_bound_geom.mod 
+subbnds.o: ../femlib/mod/intp_fem_file.mod
+subboxa.o: ../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod femtime.h modules.h \
+		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro.mod subboxa.h \
+		../femlib/mod/mod_hydro_vel.mod \
 		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_conz.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_ts.mod 
-subdep.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod 
-subdif.o: ../femlib/mod/mod_diff_visc_fric.mod femtime.h param.h \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod \
+		../femlib/mod/evgeom.mod param.h \
 		../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod 
-subdry.o: ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod 
+../femlib/mod/clo.mod: subclo.o
+subcon1.o: femtime.h ../femlib/mod/mod_bound_dynamic.mod simul.h \
+		../femlib/mod/levels.mod mkonst.h \
+		../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_depth.mod 
+subcoo.o: ../femlib/mod/mod_system.mod param.h
+subcoord.o: coords_cpp.h coords_utm.h coords.h coords_gb.h
+subcst.o: ../femlib/mod/mod_bound_geom.mod param.h pkonst.h \
+		../femlib/mod/mod_bnd.mod modules.h \
+		../femlib/mod/basin.mod mkonst.h 
+subcus.o: ../femlib/mod/evgeom.mod ../femlib/mod/mod_internal.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_hydro_print.mod param.h \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_ts.mod femtime.h \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
-		mkonst.h femtime.h param.h 
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro.mod 
+subdep.o: ../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/basin.mod 
+subdif.o: ../femlib/mod/mod_diff_aux.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_depth.mod femtime.h \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod 
+subdry.o: ../femlib/mod/mod_hydro_baro.mod femtime.h \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/basin.mod mkonst.h param.h \
+		../femlib/mod/mod_hydro.mod 
 subdts.o: subdts.h
-subele.o: param.h ../femlib/mod/mod_area.mod \
+subele.o: ../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
 		../femlib/mod/basin.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/levels.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro.mod param.h \
 		../femlib/mod/mod_depth.mod 
 subets.o: etsinf.h
-subetsa.o: modules.h simul.h param.h femtime.h \
+subetsa.o: ../femlib/mod/mod_ts.mod ../femlib/mod/nls.mod \
+		femtime.h modules.h ../femlib/mod/ets.mod \
+		../femlib/mod/mod_tides.mod \
+		../femlib/mod/levels.mod simul.h \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod ../femlib/mod/nls.mod \
-		../femlib/mod/mod_tides.mod ../femlib/mod/ets.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_waves.mod \
-		../femlib/mod/levels.mod 
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_depth.mod 
 ../femlib/mod/ets.mod: subetsm.o
 ../femlib/mod/extra.mod: subexta.o
-subexta.o: ../femlib/mod/mod_hydro_print.mod modules.h \
-		../femlib/mod/nls.mod simul.h param.h femtime.h 
+subexta.o: simul.h param.h ../femlib/mod/mod_hydro_print.mod \
+		femtime.h modules.h ../femlib/mod/nls.mod 
 ../femlib/mod/intp_fem_file.mod: subfemintp.o
-subflx3d.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_hydro_vel.mod femtime.h param.h \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
+subflx3d.o: femtime.h ../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod 
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_geom.mod param.h \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro.mod 
 ../femlib/mod/flux.mod: subflxa.o
-subflxa.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
-		param.h ../femlib/mod/mod_conz.mod femtime.h \
-		modules.h ../femlib/mod/nls.mod 
-subflxu.o: ../femlib/mod/levels.mod ../femlib/mod/mod_geom.mod \
+subflxa.o: ../femlib/mod/mod_conz.mod ../femlib/mod/levels.mod \
+		param.h ../femlib/mod/mod_ts.mod \
+		../femlib/mod/nls.mod femtime.h modules.h 
+subflxu.o: ../femlib/mod/mod_geom.mod ../femlib/mod/levels.mod \
 		param.h 
-subfvl.o: ../femlib/mod/levels.mod ../femlib/mod/mod_area.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod 
-subgotm.o: ../femlib/mod/levels.mod pkonst.h \
-		../femlib/mod/mod_gotm_aux.mod \
-		../femlib/mod/evgeom.mod \
+subfvl.o: ../femlib/mod/mod_area.mod ../femlib/mod/levels.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/basin.mod 
+subgotm.o: ../femlib/mod/mod_hydro_print.mod param.h \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_turbulence.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod debug_aux2.h \
-		../femlib/mod/mod_diff_visc_fric.mod femtime.h \
-		param.h 
-subgotm_mud.o: ../femlib/mod/mod_diff_visc_fric.mod femtime.h \
-		param.h debug_aux2.h ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_turbulence.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/mod_layer_thickness.mod pkonst.h \
 		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_turbulence.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_roughness.mod debug_aux2.h \
+		femtime.h 
+subgotm_mud.o: ../femlib/mod/evgeom.mod pkonst.h \
 		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/levels.mod pkonst.h 
+		../femlib/mod/mod_sinking.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/mod_hydro_print.mod debug_aux2.h \
+		femtime.h ../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_turbulence.mod \
+		../femlib/mod/mod_diff_visc_fric.mod 
 ../femlib/mod/grd.mod: subgrd.o
 subhisto.o: histo.h
-subinterpol.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod 
-subinterpol1.o: param.h ../femlib/mod/basin.mod \
+subinterpol.o: ../femlib/mod/basin.mod ../femlib/mod/mod_depth.mod \
+		param.h 
+subinterpol1.o: ../femlib/mod/basin.mod param.h \
 		../femlib/mod/mod_depth.mod 
-sublin.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod 
-sublnka.o: param.h ../femlib/mod/mod_geom.mod \
+sublin.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		param.h 
+sublnka.o: ../femlib/mod/mod_geom.mod param.h \
 		../femlib/mod/basin.mod 
-sublnkd.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/evgeom.mod param.h 
-sublnks.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		param.h femtime.h ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom_dynamic.mod 
-sublnku.o: param.h ../femlib/mod/basin.mod \
+sublnkd.o: ../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
+		param.h ../femlib/mod/mod_geom_dynamic.mod \
 		../femlib/mod/mod_geom.mod 
-sublpl.o: ../femlib/mod/basin.mod param.h ../femlib/mod/evgeom.mod
-submet.o: ../femlib/mod/basin.mod \
-		../femlib/mod/mod_bound_dynamic.mod femtime.h \
-		param.h ../femlib/mod/levels.mod \
+sublnks.o: femtime.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_geom_dynamic.mod param.h \
+		../femlib/mod/mod_geom.mod 
+sublnku.o: ../femlib/mod/mod_geom.mod param.h \
+		../femlib/mod/basin.mod 
+sublpl.o: param.h ../femlib/mod/evgeom.mod ../femlib/mod/basin.mod
+submet.o: ../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		femtime.h ../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_ts.mod param.h \
 		../femlib/mod/meteo_forcing_module.mod \
-		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/evgeom.mod 
+		../femlib/mod/basin.mod 
 ../femlib/mod/meteo_forcing_module.mod: submeteo2.o
-submeteo2.o: ../femlib/mod/basin.mod param.h femtime.h \
-		../femlib/mod/intp_fem_file.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
+submeteo2.o: ../femlib/mod/mod_depth.mod param.h \
 		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/basin.mod ../femlib/mod/levels.mod \
+		../femlib/mod/intp_fem_file.mod femtime.h \
 		../femlib/mod/evgeom.mod 
-submud.o: ../femlib/mod/mod_fluidmud.mod pkonst.h \
-		../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_bound_geom.mod \
+submud.o: ../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_hydro_print.mod \
 		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/mod_bound_geom.mod param.h \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_sinking.mod \
 		../femlib/mod/mod_gotm_aux.mod \
-		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/levels.mod pkonst.h \
 		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/basin.mod param.h \
-		../femlib/mod/mod_diff_visc_fric.mod 
-submud_dummy.o: param.h ../femlib/mod/mod_fluidmud.mod
-subn11.o: ../femlib/mod/basin.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_bnd_aux.mod mkonst.h param.h \
-		femtime.h ../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/intp_fem_file.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro.mod 
-../femlib/mod/chezy.mod: subn35.o
-subn35.o: ../femlib/mod/mod_fluidmud.mod ../femlib/mod/levels.mod \
-		pkonst.h ../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/nls.mod ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_ts.mod 
+submud_dummy.o: ../femlib/mod/mod_fluidmud.mod param.h
+subn11.o: mkonst.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_geom.mod param.h \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/basin.mod param.h \
-		../femlib/mod/mod_diff_visc_fric.mod 
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_bnd_aux.mod femtime.h \
+		../femlib/mod/intp_fem_file.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_geom_dynamic.mod pkonst.h \
+		../femlib/mod/levels.mod 
+../femlib/mod/chezy.mod: subn35.o
+subn35.o: ../femlib/mod/levels.mod pkonst.h ../femlib/mod/nls.mod \
+		../femlib/mod/mod_roughness.mod param.h \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_fluidmud.mod 
 ../femlib/mod/evgeom.mod: subnev.o
 subnev.o: param.h ../femlib/mod/basin.mod
 ../femlib/mod/nls.mod: subnls.o
 subnos.o: nosinf.h
-subnosa.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
-		param.h 
-subnsa.o: simul.h param.h
-subnsh.o: simul.h modules.h femtime.h param.h \
-		../femlib/mod/basin.mod ../femlib/mod/nls.mod \
-		semi.h ../femlib/mod/levels.mod 
+subnosa.o: param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod 
+subnsa.o: param.h simul.h
+subnsh.o: semi.h param.h ../femlib/mod/basin.mod simul.h \
+		../femlib/mod/levels.mod femtime.h modules.h \
+		../femlib/mod/nls.mod 
 subnsu.o: ../femlib/mod/basin.mod param.h
 ../femlib/mod/mod_offline.mod: suboff.o
 suboff.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_print.mod \
+		femtime.h ../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod param.h \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_vel.mod femtime.h param.h 
+		../femlib/mod/mod_hydro_vel.mod 
 subous.o: ousinf.h
-subousa.o: ../femlib/mod/levels.mod ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod param.h femtime.h \
-		../femlib/mod/mod_hydro.mod simul.h 
-subouta.o: ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod simul.h \
-		../femlib/mod/mod_hydro_baro.mod param.h femtime.h 
+subousa.o: femtime.h ../femlib/mod/basin.mod simul.h param.h \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro.mod 
+subouta.o: simul.h param.h ../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod femtime.h \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/basin.mod 
 suboutput.o: femtime.h
 suboutputd.o: femtime.h
 ../femlib/mod/para.mod: subpar3.o
 subpard.o: param.h ../femlib/mod/mod_system.mod \
-		$(MKLROOT)/../compiler/include/intel64/omp_lib.mod ../femlib/mod/basin.mod 
-subproj.o: ../femlib/mod/mod_tides.mod param.h \
 		../femlib/mod/basin.mod 
+subproj.o: ../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_tides.mod 
 subqfxf.o: subqfx.h
 subqfxm1.o: subqfxm.h
 subqfxm2.o: subqfxm.h
 subqfxm3.o: subqfxm.h
 subqfxm4.o: subqfxm.h
 subqfxm5.o: subqfxm.h
-subqfxt.o: subqfxm.h ../femlib/mod/mod_ts.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_meteo.mod param.h 
+subqfxt.o: subqfxm.h ../femlib/mod/levels.mod param.h \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_meteo.mod 
 subqfxu4.o: subqfxm.h
-subreg.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/evgeom.mod \
-		reg.h param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod 
-subres.o: simul.h param.h femtime.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
+subreg.o: reg.h ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro.mod param.h 
+subres.o: ../femlib/mod/mod_ts.mod femtime.h \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod 
-subrst.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_conz.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod simul.h \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_vel.mod femtime.h param.h 
-subspk.o: ../femlib/mod/basin.mod ../femlib/mod/mod_system.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_depth.mod param.h 
+subrst.o: ../femlib/mod/mod_hydro_vel.mod ../femlib/mod/basin.mod \
+		param.h ../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_hydro.mod femtime.h \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod 
+subspk.o: ../femlib/mod/mod_system.mod ../femlib/mod/basin.mod \
 		param.h 
 subtime.o: femtime.h
-subtrace.o: ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_vel.mod femtime.h param.h \
-		../femlib/mod/levels.mod \
+subtrace.o: param.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/levels.mod femtime.h \
 		../femlib/mod/mod_hydro_baro.mod 
 subtsuvfile.o: param.h ../femlib/mod/intp_fem_file.mod
-subuti.o: ../femlib/mod/mod_ts.mod ../femlib/mod/mod_depth.mod \
-		pkonst.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		param.h 
-subvola.o: volcomp.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod modules.h param.h \
-		femtime.h 
-subwat.o: ../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro.mod param.h 
-subwaves.o: ../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		pkonst.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_waves.mod param.h femtime.h 
-../femlib/mod/mod_renewal_time.mod: subwrt.o
-subwrt.o: simul.h param.h femtime.h ../femlib/mod/basin.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_conz.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/levels.mod 
-tideg.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
-		pkonst.h ../femlib/mod/mod_hydro.mod param.h \
-		../femlib/mod/mod_tides.mod 
-ts2nc.o: param.h simul.h ../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+subuti.o: ../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_depth.mod 
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod pkonst.h 
+subvola.o: param.h ../femlib/mod/mod_geom.mod modules.h volcomp.h \
+		femtime.h ../femlib/mod/basin.mod 
+subwat.o: ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom.mod param.h 
+subwaves.o: ../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/mod_hydro_baro.mod femtime.h \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_waves.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/evgeom.mod pkonst.h \
+		../femlib/mod/mod_internal.mod 
+../femlib/mod/mod_renewal_time.mod: subwrt.o
+subwrt.o: ../femlib/mod/basin.mod ../femlib/mod/mod_conz.mod \
+		param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/evgeom.mod femtime.h \
+		../femlib/mod/levels.mod simul.h 
+tideg.o: pkonst.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_tides.mod param.h \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod 
+ts2nc.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod simul.h param.h \
+		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
 tsinf.o: ../femlib/mod/clo.mod
 weutro.o: weutro.h donata.h
 weutro_sedim.o: donata.h weutro.h
 zinit.o: ../femlib/mod/basin.mod param.h simul.h
-aquabc_II.o: ../femlib/mod/para_aqua.mod \
-		../femlib/mod/aquabc_II_sed_ini.mod param.h 
+aquabc_II.o: ../femlib/mod/aquabc_II_sed_ini.mod param.h \
+		../femlib/mod/para_aqua.mod 
 ../femlib/mod/aquabc_II_sed_ini.mod: aquabc_II_ased_ini.o
 aquabc_II_ased_ini.o: aquabc_II.h nbasin.h \
 		../femlib/mod/para_aqua.mod 
@@ -1418,11 +1429,12 @@ aquabc_II_ased_ini.o: aquabc_II.h nbasin.h \
 ../femlib/mod/VECTOR_MATRIX_UTILS.mod: aquabc_II_co2sys.o
 ../femlib/mod/CO2SYS_CDIAC.mod: aquabc_II_co2sys.o
 aquabc_II_pelagic_lib.o: ../femlib/mod/AQUABC_II_GLOBAL.mod
-aquabc_II_pelagic_model.o: param.h ../femlib/mod/CO2SYS_CDIAC.mod \
-		../femlib/mod/para_aqua.mod \
-		../femlib/mod/AQUABC_II_GLOBAL.mod 
+aquabc_II_pelagic_model.o: ../femlib/mod/para_aqua.mod \
+		../femlib/mod/CO2SYS_CDIAC.mod \
+		../femlib/mod/AQUABC_II_GLOBAL.mod param.h 
 aquabc_II_sediment_lib.o: ../femlib/mod/AQUABC_II_GLOBAL.mod
-aquabc_II_sediment_model_1.o: ../femlib/mod/AQUABC_II_GLOBAL.mod \
-		../femlib/mod/para_aqua.mod \
-		../femlib/mod/CO2SYS_CDIAC.mod param.h 
+aquabc_II_sediment_model_1.o: param.h \
+		../femlib/mod/AQUABC_II_GLOBAL.mod \
+		../femlib/mod/CO2SYS_CDIAC.mod \
+		../femlib/mod/para_aqua.mod 
 

--- a/fem3d/Makefile
+++ b/fem3d/Makefile
@@ -1329,7 +1329,7 @@ suboutput.o: femtime.h
 suboutputd.o: femtime.h
 ../femlib/mod/para.mod: subpar3.o
 subpard.o: param.h ../femlib/mod/mod_system.mod \
-		../femlib/mod/omp_lib.mod ../femlib/mod/basin.mod 
+		$(MKLROOT)/../compiler/include/intel64/omp_lib.mod ../femlib/mod/basin.mod 
 subproj.o: ../femlib/mod/mod_tides.mod param.h \
 		../femlib/mod/basin.mod 
 subqfxf.o: subqfx.h

--- a/fem3d/Makefile
+++ b/fem3d/Makefile
@@ -722,111 +722,111 @@ last:
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 ../femlib/mod/para_aqua.mod: aquabc_II_apara.o
-aquabc_II_fem_interface.o: aquabc_II.h param.h \
-		../femlib/mod/aquabc_II_sed_ini.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		femtime.h mkonst.h ../femlib/mod/levels.mod \
-		../femlib/mod/para_aqua.mod aquabc_II_aout.h \
-		../femlib/mod/mod_diff_visc_fric.mod 
+aquabc_II_fem_interface.o: ../femlib/mod/basin.mod \
+		../femlib/mod/para_aqua.mod \
+		../femlib/mod/aquabc_II_sed_ini.mod mkonst.h \
+		../femlib/mod/mod_diff_visc_fric.mod param.h \
+		aquabc_II_aout.h femtime.h \
+		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		aquabc_II.h 
 aquabc_II_util.o: param.h
-atoxi3d.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_diff_visc_fric.mod mkonst.h 
-basbathy.o: pkonst.h param.h ../femlib/mod/mod_depth.mod \
+atoxi3d.o: param.h mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/levels.mod ../femlib/mod/basin.mod 
+basbathy.o: param.h simul.h ../femlib/mod/evgeom.mod pkonst.h \
 		../femlib/mod/basin.mod ../femlib/mod/grd.mod \
-		../femlib/mod/evgeom.mod simul.h 
-basbox.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom.mod 
-baschk.o: pkonst.h param.h ../femlib/mod/basin.mod \
-		../femlib/mod/evgeom.mod simul.h 
-bascomp.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
+basbox.o: ../femlib/mod/mod_depth.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/basin.mod param.h \
 		../femlib/mod/evgeom.mod 
-bashsigma.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
-basinf.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
+baschk.o: pkonst.h ../femlib/mod/basin.mod param.h \
+		../femlib/mod/evgeom.mod simul.h 
+bascomp.o: ../femlib/mod/basin.mod param.h \
+		../femlib/mod/evgeom.mod 
+bashsigma.o: param.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
+basinf.o: param.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod 
 basproj.o: param.h ../femlib/mod/basin.mod
-basres.o: param.h ../femlib/mod/basin.mod
-bastreat.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/grd.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom.mod 
-baswork.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom.mod 
+basres.o: ../femlib/mod/basin.mod param.h
+bastreat.o: ../femlib/mod/grd.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/evgeom.mod param.h 
+baswork.o: ../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/evgeom.mod 
 bdist.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom.mod 
-bio3d.o: param.h ../femlib/mod/levels.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_diff_visc_fric.mod mkonst.h 
-bio3d_util.o: ../femlib/mod/levels.mod param.h \
-		../femlib/mod/basin.mod donata.h 
+bio3d.o: ../femlib/mod/mod_diff_visc_fric.mod mkonst.h param.h \
+		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
+bio3d_util.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/levels.mod donata.h 
 debug.o: debug_aux1.h
 ../femlib/mod/elabutil.mod: elabutil.o
-elabutil.o: ../femlib/mod/mod_depth.mod ../femlib/mod/levels.mod \
-		param.h ../femlib/mod/clo.mod \
-		../femlib/mod/basin.mod 
+elabutil.o: param.h ../femlib/mod/clo.mod ../femlib/mod/levels.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
 eosinf.o: param.h
 etsinf.o: param.h ../femlib/mod/ets.mod
-extelab1.o: ../femlib/mod/levels.mod ../femlib/mod/mod_depth.mod \
-		../femlib/mod/clo.mod ../femlib/mod/basin.mod \
-		../femlib/mod/elabutil.mod \
-		../femlib/mod/evgeom.mod 
+extelab1.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
+		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/clo.mod ../femlib/mod/elabutil.mod 
 femelab.o: ../femlib/mod/clo.mod
 feminf.o: ../femlib/mod/clo.mod
 filetype.o: ../femlib/mod/clo.mod
 flxinf.o: param.h
 gotm3d.o: gotmturb.i debug_aux1.h
-grdutil.o: ../femlib/mod/basin.mod ../femlib/mod/grd.mod
-intp.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod 
-lagrange_back.o: ../femlib/mod/mod_depth.mod param.h \
+grdutil.o: ../femlib/mod/grd.mod ../femlib/mod/basin.mod
+intp.o: ../femlib/mod/basin.mod ../femlib/mod/mod_hydro.mod \
+		param.h 
+lagrange_back.o: ../femlib/mod/mod_hydro.mod lagrange.h param.h \
 		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod lagrange.h 
-lagrange_cont.o: param.h ../femlib/mod/basin.mod lagrange.h \
-		../femlib/mod/mod_geom.mod 
-lagrange_decay.o: param.h femtime.h lagrange.h
-lagrange_dif.o: param.h femtime.h lagrange.h
-lagrange_flux.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod femtime.h \
-		../femlib/mod/evgeom.mod lagrange.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
-lagrange_init.o: param.h ../femlib/mod/basin.mod lagrange.h
-lagrange_inout.o: ../femlib/mod/levels.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/lgr_sedim_module.mod femtime.h \
-		lagrange.h 
-lagrange_larve.o: param.h lagrange.h
-lagrange_main.o: param.h ../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/lgr_sedim_module.mod lagrange.h 
-lagrange_oil.o: param.h ../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod lagrange.h 
-../femlib/mod/lgr_sedim_module.mod: lagrange_sedim.o
-lagrange_sedim.o: param.h ../femlib/mod/levels.mod lagrange.h
-lagrange_track.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod lagrange.h \
-		../femlib/mod/mod_geom.mod 
-lagrange_util.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/evgeom.mod 
-lagrange_util_tr.o: param.h ../femlib/mod/basin.mod
-lagrange_vertical.o: ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod lagrange.h \
-		../femlib/mod/mod_geom.mod 
-lgrelab.o: param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_hydro_print.mod 
+lagrange_cont.o: lagrange.h param.h ../femlib/mod/mod_geom.mod \
 		../femlib/mod/basin.mod 
+lagrange_decay.o: param.h lagrange.h femtime.h
+lagrange_dif.o: param.h lagrange.h femtime.h
+lagrange_flux.o: ../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		femtime.h lagrange.h param.h \
+		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod 
+lagrange_init.o: ../femlib/mod/basin.mod lagrange.h param.h
+lagrange_inout.o: femtime.h lagrange.h param.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/lgr_sedim_module.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod 
+lagrange_larve.o: param.h lagrange.h
+lagrange_main.o: ../femlib/mod/basin.mod \
+		../femlib/mod/lgr_sedim_module.mod femtime.h \
+		param.h lagrange.h 
+lagrange_oil.o: femtime.h lagrange.h param.h \
+		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod 
+../femlib/mod/lgr_sedim_module.mod: lagrange_sedim.o
+lagrange_sedim.o: ../femlib/mod/levels.mod lagrange.h param.h
+lagrange_track.o: lagrange.h param.h ../femlib/mod/mod_geom.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/levels.mod 
+lagrange_util.o: ../femlib/mod/evgeom.mod param.h \
+		../femlib/mod/basin.mod 
+lagrange_util_tr.o: param.h ../femlib/mod/basin.mod
+lagrange_vertical.o: ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod lagrange.h param.h \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod 
+lgrelab.o: ../femlib/mod/basin.mod ../femlib/mod/mod_depth.mod \
+		param.h 
 lgrinf.o: param.h
 loading.o: param.h ../femlib/mod/levels.mod \
 		../femlib/mod/basin.mod 
-map_influence.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod 
+map_influence.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
 ../femlib/mod/mod_area.mod: mod_area.o
 ../femlib/mod/mod_bclfix.mod: mod_bclfix.o
 ../femlib/mod/mod_bnd.mod: mod_bnd.o
@@ -861,578 +861,568 @@ mod_subset.o: ../femlib/mod/basin.mod
 ../femlib/mod/mod_turbulence.mod: mod_turbulence.o
 ../femlib/mod/mod_tvd.mod: mod_tvd.o
 ../femlib/mod/mod_waves.mod: mod_waves.o
-netcdf.o: ../femlib/mod/mod_depth.mod ../femlib/mod/levels.mod \
-		param.h ../femlib/mod/basin.mod netcdf.h \
-		netcdf.inc 
-netcdf_util.o: param.h ../femlib/mod/basin.mod
-new36.o: param.h ../femlib/mod/basin.mod mkonst.h femtime.h \
-		close.h ../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_diff_visc_fric.mod 
-new3di.o: ../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_waves.mod \
-		../femlib/mod/mod_layer_thickness.mod mkonst.h \
-		../femlib/mod/mod_bound_geom.mod \
+netcdf.o: netcdf.h netcdf.inc param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
+netcdf_util.o: ../femlib/mod/basin.mod param.h
+new36.o: close.h ../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_print.mod mkonst.h \
+		../femlib/mod/mod_diff_visc_fric.mod param.h \
+		femtime.h 
+new3di.o: ../femlib/mod/evgeom.mod ../femlib/mod/mod_roughness.mod \
 		../femlib/mod/mod_tides.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_roughness.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_internal.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_dynamic.mod pkonst.h \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_depth.mod pkonst.h \
 		../femlib/mod/levels.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_nudging.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod 
-newbcl.o: param.h ../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		mkonst.h femtime.h \
-		../femlib/mod/mod_layer_thickness.mod pkonst.h \
-		../femlib/mod/levels.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod 
-newchao.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod femtime.h 
-newchk.o: ../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_ts.mod mkonst.h \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_hydro_baro.mod param.h \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_print.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_meteo.mod 
-newcon.o: ../femlib/mod/mod_area.mod ../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_layer_thickness.mod mkonst.h \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_geom.mod param.h \
-		../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_diff_aux.mod 
-newcon_omp.o: ../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_subset.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/mod_geom.mod 
-newconz.o: param.h ../femlib/mod/mod_ts.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod mkonst.h \
-		femtime.h ../femlib/mod/mod_conz.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_diff_visc_fric.mod 
-newcra.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod mkonst.h femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_dynamic.mod pkonst.h \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_bnd_aux.mod \
-		../femlib/mod/mod_hydro.mod 
-newexpl.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/mod_ts.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_waves.mod mkonst.h \
+		../femlib/mod/mod_diff_visc_fric.mod param.h \
+		femtime.h 
+newbcl.o: ../femlib/mod/mod_diff_visc_fric.mod mkonst.h femtime.h \
+		param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod pkonst.h \
+		../femlib/mod/mod_ts.mod pkonst.h \
+		../femlib/mod/levels.mod 
+newchao.o: ../femlib/mod/levels.mod ../femlib/mod/basin.mod \
+		femtime.h param.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_baro.mod 
+newchk.o: ../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_ts.mod param.h femtime.h \
+		mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_dynamic.mod 
+newcon.o: mkonst.h femtime.h param.h ../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_diff_aux.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_layer_thickness.mod 
+newcon_omp.o: ../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro.mod \
 		../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_subset.mod \
+		../femlib/mod/mod_area.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_diff_aux.mod \
+		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_bound_dynamic.mod 
+newconz.o: ../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_conz.mod ../femlib/mod/basin.mod \
+		mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
+		param.h femtime.h 
+newcra.o: ../femlib/mod/mod_bnd_aux.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod param.h femtime.h mkonst.h \
+		pkonst.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_baro.mod 
+newexpl.o: ../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod \
+		pkonst.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_print.mod \
 		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_internal.mod param.h 
+newfix.o: ../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
-newfix.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/levels.mod param.h femtime.h \
 		../femlib/mod/mod_internal.mod \
-		../femlib/mod/mod_bclfix.mod femtime.h \
-		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_bclfix.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro.mod 
-newini.o: param.h ../femlib/mod/mod_internal.mod \
-		../femlib/mod/basin.mod mkonst.h pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/basin.mod 
+newini.o: mkonst.h ../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_internal.mod param.h \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_roughness.mod 
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/levels.mod pkonst.h 
 ../femlib/mod/levels.mod: newlevels.o
 ../femlib/mod/mod_nudge.mod: newnudge.o
-newnudge.o: ../femlib/mod/mod_internal.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod femtime.h \
+newnudge.o: ../femlib/mod/basin.mod ../femlib/mod/mod_nudging.mod \
+		../femlib/mod/mod_internal.mod femtime.h \
 		../femlib/mod/levels.mod \
-		../femlib/mod/mod_nudging.mod \
+		../femlib/mod/intp_fem_file.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/intp_fem_file.mod 
+		../femlib/mod/mod_layer_thickness.mod 
 newrog.o: param.h ../femlib/mod/basin.mod
-newstab.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_diff_visc_fric.mod stab.h \
-		../femlib/mod/mod_conz.mod 
-newtra.o: ../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
+newstab.o: ../femlib/mod/basin.mod ../femlib/mod/levels.mod stab.h \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_conz.mod param.h 
+newtra.o: ../femlib/mod/mod_depth.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_hydro_print.mod param.h 
+newtvd.o: param.h ../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod 
-newtvd.o: ../femlib/mod/mod_hydro_vel.mod ../femlib/mod/levels.mod \
-		param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_tvd.mod \
-		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod 
-nos2nc.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod 
-noselab1.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod ../femlib/mod/clo.mod \
-		../femlib/mod/basin.mod ../femlib/mod/elabutil.mod \
-		../femlib/mod/evgeom.mod 
-nosextr_nodes.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
-nosresidence.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
-optintp.o: param.h ../femlib/mod/clo.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod 
-ous2nc.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod 
-ouselab1.o: ../femlib/mod/mod_depth.mod ../femlib/mod/clo.mod \
-		../femlib/mod/basin.mod ../femlib/mod/elabutil.mod \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_tvd.mod ../femlib/mod/levels.mod 
+nos2nc.o: ../femlib/mod/levels.mod ../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod param.h \
+		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_hydro.mod 
+noselab1.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
+		../femlib/mod/levels.mod ../femlib/mod/clo.mod \
+		../femlib/mod/evgeom.mod param.h \
+		../femlib/mod/elabutil.mod 
+nosextr_nodes.o: ../femlib/mod/levels.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod param.h \
+		../femlib/mod/evgeom.mod 
+nosresidence.o: ../femlib/mod/evgeom.mod param.h \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod ../femlib/mod/levels.mod 
+optintp.o: param.h ../femlib/mod/clo.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
+ous2nc.o: param.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
+ouselab1.o: ../femlib/mod/elabutil.mod ../femlib/mod/clo.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod 
 ousutil.o: ../femlib/mod/evgeom.mod
 readext.o: param.h ../femlib/mod/basin.mod
-scal_intp.o: param.h ../femlib/mod/basin.mod \
+scal_intp.o: ../femlib/mod/basin.mod param.h \
 		../femlib/mod/evgeom.mod 
-scalintp.o: pkonst.h param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		simul.h 
-sedi3d.o: ../femlib/mod/mod_area.mod \
+scalintp.o: simul.h ../femlib/mod/evgeom.mod param.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod pkonst.h 
+sedi3d.o: param.h ../femlib/mod/mod_diff_visc_fric.mod \
 		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_hydro.mod \
 		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_waves.mod \
-		../femlib/mod/mod_layer_thickness.mod \
 		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_geom.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		sed_param.h ../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod 
-shyelab.o: ../femlib/mod/clo.mod ../femlib/mod/elabutil.mod
-shyfem.o: ../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_tides.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod sed_param.h 
+shyelab.o: ../femlib/mod/elabutil.mod ../femlib/mod/clo.mod
+shyfem.o: mkonst.h param.h ../femlib/mod/mod_hydro.mod \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_roughness.mod param.h \
-		../femlib/mod/mod_bclfix.mod \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_conz.mod pkonst.h \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_bndo.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_nohyd.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_area.mod \
 		../femlib/mod/mod_hydro_print.mod \
 		../femlib/mod/mod_nudging.mod \
-		../femlib/mod/mod_bnd_aux.mod \
+		../femlib/mod/mod_tides.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/intp_fem_file.mod \
+		../femlib/mod/mod_bclfix.mod \
+		../femlib/mod/mod_diff_visc_fric.mod femtime.h \
 		../femlib/mod/mod_bnd.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/mod_waves.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_nohyd.mod \
-		../femlib/mod/mod_layer_thickness.mod mkonst.h \
-		../femlib/mod/mod_subset.mod \
-		../femlib/mod/mod_bndo.mod \
-		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
-		femtime.h ../femlib/mod/mod_gotm_aux.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod ../femlib/mod/mod_tvd.mod \
+		../femlib/mod/mod_bnd_aux.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
 		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_tvd.mod \
+		../femlib/mod/mod_waves.mod \
+		../femlib/mod/mod_internal.mod \
 		../femlib/mod/mod_turbulence.mod \
-		../femlib/mod/intp_fem_file.mod 
+		../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_diff_aux.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_subset.mod \
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/mod_fluidmud.mod pkonst.h \
+		../femlib/mod/levels.mod 
 shypre.o: ../femlib/mod/clo.mod param.h ../femlib/mod/basin.mod
 sigmautil.o: sigma.h
-simsys_lp.o: param.h ../femlib/mod/mod_system.mod \
+simsys_lp.o: ../femlib/mod/mod_system.mod param.h \
 		../femlib/mod/basin.mod 
 simsys_pard.o: param.h ../femlib/mod/mod_system.mod \
 		../femlib/mod/basin.mod 
-simsys_spk.o: param.h ../femlib/mod/mod_system.mod \
-		../femlib/mod/basin.mod 
+simsys_spk.o: ../femlib/mod/basin.mod ../femlib/mod/mod_system.mod \
+		param.h 
 splitets.o: param.h
 splitflx.o: param.h
 subapn.o: ../femlib/mod/basin.mod
 ../femlib/mod/basin.mod: subbas.o
 subbas.o: param.h
-subbfm.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		pkonst.h ../femlib/mod/levels.mod \
+subbfm.o: bfm_common.h ../femlib/mod/mod_diff_visc_fric.mod \
+		param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod bfm_common.h 
-subbnd.o: param.h bound_names.h ../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bnd.mod 
-subbndo.o: ../femlib/mod/levels.mod param.h \
-		../femlib/mod/mod_bndo.mod ../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_sinking.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod pkonst.h 
+subbnd.o: bound_names.h param.h ../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_bnd.mod 
+subbndo.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/mod_bndo.mod \
+		param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_geom.mod \
 		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_geom.mod 
+		../femlib/mod/levels.mod 
 subbnds.o: ../femlib/mod/intp_fem_file.mod
-subboxa.o: ../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod subboxa.h femtime.h \
+subboxa.o: ../femlib/mod/mod_ts.mod ../femlib/mod/mod_meteo.mod \
 		../femlib/mod/mod_conz.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro.mod modules.h \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom_dynamic.mod param.h \
+		subboxa.h femtime.h \
 		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_meteo.mod 
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod modules.h 
 ../femlib/mod/clo.mod: subclo.o
-subcon1.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod femtime.h mkonst.h simul.h \
-		../femlib/mod/mod_bound_dynamic.mod \
+subcon1.o: ../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod simul.h mkonst.h femtime.h \
+		param.h ../femlib/mod/mod_depth.mod \
 		../femlib/mod/levels.mod 
 subcoo.o: param.h ../femlib/mod/mod_system.mod
-subcoord.o: coords_cpp.h coords.h coords_utm.h coords_gb.h
-subcst.o: pkonst.h param.h ../femlib/mod/basin.mod modules.h \
-		mkonst.h ../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bnd.mod 
-subcus.o: ../femlib/mod/mod_area.mod \
-		../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_hydro_baro.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/evgeom.mod femtime.h \
-		../femlib/mod/mod_conz.mod \
-		../femlib/mod/levels.mod \
+subcoord.o: coords_utm.h coords_cpp.h coords_gb.h coords.h
+subcst.o: modules.h mkonst.h param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/mod_bnd.mod pkonst.h 
+subcus.o: ../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_hydro_print.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_meteo.mod 
-subdep.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod 
-subdif.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_diff_aux.mod \
-		../femlib/mod/mod_geom.mod 
-subdry.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod mkonst.h femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod 
-subdts.o: subdts.h
-subele.o: ../femlib/mod/mod_area.mod ../femlib/mod/mod_depth.mod \
-		param.h ../femlib/mod/basin.mod \
-		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_area.mod ../femlib/mod/basin.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro.mod 
-subets.o: etsinf.h
-subetsa.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_waves.mod ../femlib/mod/ets.mod \
-		femtime.h ../femlib/mod/mod_tides.mod simul.h \
-		../femlib/mod/levels.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/mod_depth.mod param.h femtime.h \
+		../femlib/mod/mod_diff_visc_fric.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_ts.mod 
+subdep.o: param.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod 
+subdif.o: ../femlib/mod/mod_diff_visc_fric.mod femtime.h param.h \
+		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/mod_diff_aux.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod modules.h \
-		../femlib/mod/nls.mod 
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod 
+subdry.o: ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/basin.mod \
+		mkonst.h femtime.h param.h 
+subdts.o: subdts.h
+subele.o: param.h ../femlib/mod/mod_area.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod 
+subets.o: etsinf.h
+subetsa.o: modules.h simul.h param.h femtime.h \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_hydro.mod ../femlib/mod/nls.mod \
+		../femlib/mod/mod_tides.mod ../femlib/mod/ets.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_waves.mod \
+		../femlib/mod/levels.mod 
 ../femlib/mod/ets.mod: subetsm.o
 ../femlib/mod/extra.mod: subexta.o
-subexta.o: param.h ../femlib/mod/mod_hydro_print.mod modules.h \
-		femtime.h simul.h ../femlib/mod/nls.mod 
+subexta.o: ../femlib/mod/mod_hydro_print.mod modules.h \
+		../femlib/mod/nls.mod simul.h param.h femtime.h 
 ../femlib/mod/intp_fem_file.mod: subfemintp.o
-subflx3d.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_geom.mod \
+subflx3d.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
 		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_hydro_vel.mod femtime.h param.h \
+		../femlib/mod/mod_bound_geom.mod \
 		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
 		../femlib/mod/mod_hydro_baro.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
+		../femlib/mod/evgeom.mod 
 ../femlib/mod/flux.mod: subflxa.o
-subflxa.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_ts.mod modules.h femtime.h \
-		../femlib/mod/mod_conz.mod ../femlib/mod/nls.mod 
-subflxu.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_geom.mod 
-subfvl.o: ../femlib/mod/mod_area.mod ../femlib/mod/levels.mod \
+subflxa.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
+		param.h ../femlib/mod/mod_conz.mod femtime.h \
+		modules.h ../femlib/mod/nls.mod 
+subflxu.o: ../femlib/mod/levels.mod ../femlib/mod/mod_geom.mod \
+		param.h 
+subfvl.o: ../femlib/mod/levels.mod ../femlib/mod/mod_area.mod \
 		../femlib/mod/basin.mod \
 		../femlib/mod/mod_layer_thickness.mod 
-subgotm.o: ../femlib/mod/mod_ts.mod \
+subgotm.o: ../femlib/mod/levels.mod pkonst.h \
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/mod_roughness.mod param.h \
-		debug_aux2.h ../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_gotm_aux.mod pkonst.h \
-		../femlib/mod/levels.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_vel.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_turbulence.mod 
-subgotm_mud.o: ../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_turbulence.mod \
 		../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_roughness.mod param.h \
-		debug_aux2.h ../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_gotm_aux.mod pkonst.h \
-		../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_meteo.mod debug_aux2.h \
+		../femlib/mod/mod_diff_visc_fric.mod femtime.h \
+		param.h 
+subgotm_mud.o: ../femlib/mod/mod_diff_visc_fric.mod femtime.h \
+		param.h debug_aux2.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_sinking.mod \
+		../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_turbulence.mod \
+		../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_vel.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_turbulence.mod 
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_fluidmud.mod \
+		../femlib/mod/levels.mod pkonst.h 
 ../femlib/mod/grd.mod: subgrd.o
 subhisto.o: histo.h
 subinterpol.o: param.h ../femlib/mod/mod_depth.mod \
 		../femlib/mod/basin.mod 
-subinterpol1.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod 
+subinterpol1.o: param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
 sublin.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom.mod 
-sublnka.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_geom.mod 
-sublnkd.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom.mod 
-sublnks.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		femtime.h ../femlib/mod/mod_geom.mod 
+sublnka.o: param.h ../femlib/mod/mod_geom.mod \
+		../femlib/mod/basin.mod 
+sublnkd.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/evgeom.mod param.h 
+sublnks.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		param.h femtime.h ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_geom_dynamic.mod 
 sublnku.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom.mod 
-sublpl.o: param.h ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod
-submet.o: param.h ../femlib/mod/mod_ts.mod ../femlib/mod/basin.mod \
-		femtime.h ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_bound_dynamic.mod \
+sublpl.o: ../femlib/mod/basin.mod param.h ../femlib/mod/evgeom.mod
+submet.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_dynamic.mod femtime.h \
+		param.h ../femlib/mod/levels.mod \
 		../femlib/mod/meteo_forcing_module.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_meteo.mod 
-../femlib/mod/meteo_forcing_module.mod: submeteo2.o
-submeteo2.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		femtime.h ../femlib/mod/levels.mod \
+		../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/intp_fem_file.mod 
-submud.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/evgeom.mod 
+../femlib/mod/meteo_forcing_module.mod: submeteo2.o
+submeteo2.o: ../femlib/mod/basin.mod param.h femtime.h \
+		../femlib/mod/intp_fem_file.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/evgeom.mod 
+submud.o: ../femlib/mod/mod_fluidmud.mod pkonst.h \
+		../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
 		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bound_dynamic.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_sinking.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_roughness.mod 
-submud_dummy.o: param.h ../femlib/mod/mod_fluidmud.mod
-subn11.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod mkonst.h femtime.h \
-		../femlib/mod/mod_bound_geom.mod \
-		../femlib/mod/mod_bound_dynamic.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_bnd_aux.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/intp_fem_file.mod 
-../femlib/mod/chezy.mod: subn35.o
-subn35.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_fluidmud.mod \
-		../femlib/mod/mod_layer_thickness.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_diff_visc_fric.mod \
-		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_depth.mod \
 		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/nls.mod 
+		../femlib/mod/mod_sinking.mod \
+		../femlib/mod/mod_gotm_aux.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_diff_visc_fric.mod 
+submud_dummy.o: param.h ../femlib/mod/mod_fluidmud.mod
+subn11.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_bound_dynamic.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/mod_bnd_aux.mod mkonst.h param.h \
+		femtime.h ../femlib/mod/mod_bound_geom.mod \
+		../femlib/mod/intp_fem_file.mod pkonst.h \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro.mod 
+../femlib/mod/chezy.mod: subn35.o
+subn35.o: ../femlib/mod/mod_fluidmud.mod ../femlib/mod/levels.mod \
+		pkonst.h ../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_roughness.mod \
+		../femlib/mod/nls.mod ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_diff_visc_fric.mod 
 ../femlib/mod/evgeom.mod: subnev.o
 subnev.o: param.h ../femlib/mod/basin.mod
 ../femlib/mod/nls.mod: subnls.o
 subnos.o: nosinf.h
-subnosa.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod 
-subnsa.o: param.h simul.h
-subnsh.o: param.h ../femlib/mod/basin.mod semi.h femtime.h simul.h \
-		../femlib/mod/levels.mod modules.h \
-		../femlib/mod/nls.mod 
-subnsu.o: param.h ../femlib/mod/basin.mod
+subnosa.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
+		param.h 
+subnsa.o: simul.h param.h
+subnsh.o: simul.h modules.h femtime.h param.h \
+		../femlib/mod/basin.mod ../femlib/mod/nls.mod \
+		semi.h ../femlib/mod/levels.mod 
+subnsu.o: ../femlib/mod/basin.mod param.h
 ../femlib/mod/mod_offline.mod: suboff.o
-suboff.o: ../femlib/mod/mod_hydro_vel.mod param.h \
-		../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
-		../femlib/mod/basin.mod \
+suboff.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_hydro.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod femtime.h 
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_vel.mod femtime.h param.h 
 subous.o: ousinf.h
-subousa.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod femtime.h simul.h 
-subouta.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro_baro.mod \
+subousa.o: ../femlib/mod/levels.mod ../femlib/mod/mod_depth.mod \
+		../femlib/mod/basin.mod param.h femtime.h \
+		../femlib/mod/mod_hydro.mod simul.h 
+subouta.o: ../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod femtime.h simul.h 
+		../femlib/mod/mod_hydro.mod simul.h \
+		../femlib/mod/mod_hydro_baro.mod param.h femtime.h 
 suboutput.o: femtime.h
 suboutputd.o: femtime.h
 ../femlib/mod/para.mod: subpar3.o
-subpard.o: ../femlib/mod/omp_lib.mod param.h \
-		../femlib/mod/mod_system.mod 
-subproj.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_tides.mod 
+subpard.o: param.h ../femlib/mod/mod_system.mod \
+		../femlib/mod/omp_lib.mod ../femlib/mod/basin.mod 
+subproj.o: ../femlib/mod/mod_tides.mod param.h \
+		../femlib/mod/basin.mod 
 subqfxf.o: subqfx.h
 subqfxm1.o: subqfxm.h
 subqfxm2.o: subqfxm.h
 subqfxm3.o: subqfxm.h
 subqfxm4.o: subqfxm.h
 subqfxm5.o: subqfxm.h
-subqfxt.o: param.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_ts.mod subqfxm.h \
-		../femlib/mod/mod_meteo.mod 
+subqfxt.o: subqfxm.h ../femlib/mod/mod_ts.mod \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_meteo.mod param.h 
 subqfxu4.o: subqfxm.h
-subreg.o: reg.h param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod \
+subreg.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/evgeom.mod \
+		reg.h param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom.mod 
-subres.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/mod_ts.mod ../femlib/mod/basin.mod \
-		femtime.h simul.h ../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod 
-subrst.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod ../femlib/mod/mod_ts.mod \
-		femtime.h ../femlib/mod/mod_conz.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro.mod 
-subspk.o: param.h ../femlib/mod/mod_system.mod \
-		../femlib/mod/basin.mod 
-subtime.o: femtime.h
-subtrace.o: ../femlib/mod/mod_geom_dynamic.mod param.h \
-		../femlib/mod/basin.mod femtime.h \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod 
-subtsuvfile.o: param.h ../femlib/mod/intp_fem_file.mod
-subuti.o: ../femlib/mod/mod_geom_dynamic.mod \
-		../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/mod_ts.mod ../femlib/mod/basin.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_baro.mod \
+subres.o: simul.h param.h femtime.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
-subvola.o: volcomp.h param.h ../femlib/mod/basin.mod modules.h \
-		femtime.h ../femlib/mod/mod_geom.mod 
-subwat.o: ../femlib/mod/levels.mod param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_geom.mod 
-subwaves.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/mod_internal.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_waves.mod \
-		../femlib/mod/mod_layer_thickness.mod \
-		../femlib/mod/evgeom.mod femtime.h pkonst.h \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
 		../femlib/mod/mod_hydro_baro.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_meteo.mod \
-		../femlib/mod/mod_roughness.mod \
-		../femlib/mod/mod_geom.mod 
-../femlib/mod/mod_renewal_time.mod: subwrt.o
-subwrt.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		femtime.h simul.h ../femlib/mod/mod_conz.mod \
-		../femlib/mod/levels.mod 
-tideg.o: pkonst.h ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_tides.mod 
-ts2nc.o: param.h ../femlib/mod/levels.mod \
 		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
+		../femlib/mod/mod_ts.mod ../femlib/mod/levels.mod 
+subrst.o: ../femlib/mod/levels.mod ../femlib/mod/mod_ts.mod \
+		../femlib/mod/mod_conz.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod simul.h 
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_vel.mod femtime.h param.h 
+subspk.o: ../femlib/mod/basin.mod ../femlib/mod/mod_system.mod \
+		param.h 
+subtime.o: femtime.h
+subtrace.o: ../femlib/mod/basin.mod \
+		../femlib/mod/mod_hydro_vel.mod femtime.h param.h \
+		../femlib/mod/levels.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_hydro_baro.mod 
+subtsuvfile.o: param.h ../femlib/mod/intp_fem_file.mod
+subuti.o: ../femlib/mod/mod_ts.mod ../femlib/mod/mod_depth.mod \
+		pkonst.h ../femlib/mod/levels.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_geom_dynamic.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+		param.h 
+subvola.o: volcomp.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_geom.mod modules.h param.h \
+		femtime.h 
+subwat.o: ../femlib/mod/mod_geom.mod ../femlib/mod/basin.mod \
+		../femlib/mod/levels.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro.mod param.h 
+subwaves.o: ../femlib/mod/mod_roughness.mod \
+		../femlib/mod/mod_layer_thickness.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		pkonst.h ../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_internal.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		../femlib/mod/mod_meteo.mod \
+		../femlib/mod/mod_hydro_baro.mod \
+		../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_waves.mod param.h femtime.h 
+../femlib/mod/mod_renewal_time.mod: subwrt.o
+subwrt.o: simul.h param.h femtime.h ../femlib/mod/basin.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_conz.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/levels.mod 
+tideg.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
+		pkonst.h ../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/mod_tides.mod 
+ts2nc.o: param.h simul.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
 tsinf.o: ../femlib/mod/clo.mod
-weutro.o: donata.h weutro.h
+weutro.o: weutro.h donata.h
 weutro_sedim.o: donata.h weutro.h
-zinit.o: param.h ../femlib/mod/basin.mod simul.h
-aquabc_II.o: param.h ../femlib/mod/aquabc_II_sed_ini.mod \
-		../femlib/mod/para_aqua.mod 
+zinit.o: ../femlib/mod/basin.mod param.h simul.h
+aquabc_II.o: ../femlib/mod/para_aqua.mod \
+		../femlib/mod/aquabc_II_sed_ini.mod param.h 
 ../femlib/mod/aquabc_II_sed_ini.mod: aquabc_II_ased_ini.o
-aquabc_II_ased_ini.o: nbasin.h aquabc_II.h \
+aquabc_II_ased_ini.o: aquabc_II.h nbasin.h \
 		../femlib/mod/para_aqua.mod 
 ../femlib/mod/AQUABC_II_GLOBAL.mod: aquabc_II_co2sys.o
 ../femlib/mod/VECTOR_MATRIX_UTILS.mod: aquabc_II_co2sys.o
 ../femlib/mod/CO2SYS_CDIAC.mod: aquabc_II_co2sys.o
 aquabc_II_pelagic_lib.o: ../femlib/mod/AQUABC_II_GLOBAL.mod
-aquabc_II_pelagic_model.o: ../femlib/mod/CO2SYS_CDIAC.mod param.h \
+aquabc_II_pelagic_model.o: param.h ../femlib/mod/CO2SYS_CDIAC.mod \
 		../femlib/mod/para_aqua.mod \
 		../femlib/mod/AQUABC_II_GLOBAL.mod 
 aquabc_II_sediment_lib.o: ../femlib/mod/AQUABC_II_GLOBAL.mod
-aquabc_II_sediment_model_1.o: ../femlib/mod/CO2SYS_CDIAC.mod \
-		param.h ../femlib/mod/para_aqua.mod \
-		../femlib/mod/AQUABC_II_GLOBAL.mod 
+aquabc_II_sediment_model_1.o: ../femlib/mod/AQUABC_II_GLOBAL.mod \
+		../femlib/mod/para_aqua.mod \
+		../femlib/mod/CO2SYS_CDIAC.mod param.h 
 

--- a/fem3d/bin/find_pardlib.sh
+++ b/fem3d/bin/find_pardlib.sh
@@ -41,7 +41,16 @@ else
 	exit 1
 fi
 
+# This is not necessary if '!$' is used in pardiso_solve
+# before 'use omp_lib'
+#if [ -e $INTEL_INCL/omp_lib.mod ]; then
+#   cp $INTEL_INCL/omp_lib.mod ../femlib/mod
+#else
+#   echo "Module file omp_lib.mod not found"
+#   exit 1
+#fi
 
+######
 # Static linking. Warning: not sure if possible with GNU licence
 #LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -Wl,--start-group $DIRLIB_MKL/lib${baselib}.a $DIRLIB_MKL/libmkl_intel_thread.a $DIRLIB_MKL/libmkl_core.a -Wl,--end-group -liomp5 -lpthread"
 

--- a/fem3d/bin/find_pardlib.sh
+++ b/fem3d/bin/find_pardlib.sh
@@ -1,35 +1,53 @@
-#!/bin/sh
+#!/bin/bash
 
-mkldir="/opt/intel/mkl"
+# Checks include directory
+if [ -d $MKLROOT/include ]; then
+   MKLINCLUDE=$MKLROOT/include
+else
+   echo "find_pardlib.sh: $MKLINCLUDE does not exist."
+   exit 1
+fi
 
 # Find machine type
 machine=`uname -m`
 if [ $machine = 'x86_64' ]; then
-	machdir='em64t'
-	lib1='libmkl_solver_lp64.a'
-	lib2='libmkl_intel_lp64.a'
+        if [ -d $MKLROOT/lib/em64t ]; then
+           DIRLIB_MKL=$MKLROOT/lib/em64t
+           INTEL_INCL=$MKLROOT/../compiler/include/em64t
+        elif [ -d $MKLROOT/lib/intel64 ]; then
+           DIRLIB_MKL=$MKLROOT/lib/intel64
+           INTEL_INCL=$MKLROOT/../compiler/include/intel64
+        else
+           echo "find_pardlib.sh: $DIRLIB_MKL does not exist."
+           exit 1
+        fi
+	baselib='mkl_intel_lp64'
+
 elif [ $machine = 'i686' ]; then
-	machdir='32'
-	lib1='libmkl_solver.a'
-	lib2='libmkl_intel.a'
+        if [ -d $MKLROOT/lib/32 ]; then
+           DIRLIB_MKL=$MKLROOT/lib/32
+           INTEL_INCL=$MKLROOT/../compiler/include/32	#to check
+        elif [ -d $MKLROOT/lib/ia32 ]; then
+           DIRLIB_MKL=$MKLROOT/lib/ia32
+           INTEL_INCL=$MKLROOT/../compiler/include/ia32	#to check
+        else
+           echo "find_pardlib.sh: $DIRLIB_MKL does not exist."
+           exit 1
+        fi
+	baselib='mkl_intel'
+
 else
 	echo "Unknown machine: $machine"
 	exit 1
 fi
 
-# Libraries with the same name
-lib3='libmkl_intel_thread.a'
-lib4='libmkl_core.a'
-lib5='libguide.a'
 
-# Find the last version directory
-versdir=`ls -rt $mkldir | tail -1`
+# Static linking. Warning: not sure if possible with GNU licence
+LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -Wl,--start-group $DIRLIB_MKL/lib${baselib}.a $DIRLIB_MKL/libmkl_intel_thread.a $DIRLIB_MKL/libmkl_core.a -Wl,--end-group -liomp5 -lpthread"
 
-# Name of the libraries dir
-DIRLIB_MKL=$mkldir/$versdir/lib/$machdir
+# Dynamic linking
+#LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -l${baselib} -lmkl_intel_thread -lmkl_core -liomp5 -lpthread"
 
-# String
-LIBG_MKL="-L$DIRLIB_MKL $DIRLIB_MKL/$lib1 $DIRLIB_MKL/$lib2 -Wl,--start-group $DIRLIB_MKL/$lib3 $DIRLIB_MKL/$lib4 -Wl,--end-group $DIRLIB_MKL/$lib5 -lpthread"
 echo "$LIBG_MKL"
 
 exit 0

--- a/fem3d/bin/find_pardlib.sh
+++ b/fem3d/bin/find_pardlib.sh
@@ -43,10 +43,10 @@ fi
 
 
 # Static linking. Warning: not sure if possible with GNU licence
-LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -Wl,--start-group $DIRLIB_MKL/lib${baselib}.a $DIRLIB_MKL/libmkl_intel_thread.a $DIRLIB_MKL/libmkl_core.a -Wl,--end-group -liomp5 -lpthread"
+#LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -Wl,--start-group $DIRLIB_MKL/lib${baselib}.a $DIRLIB_MKL/libmkl_intel_thread.a $DIRLIB_MKL/libmkl_core.a -Wl,--end-group -liomp5 -lpthread"
 
 # Dynamic linking
-#LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -l${baselib} -lmkl_intel_thread -lmkl_core -liomp5 -lpthread"
+LIBG_MKL="-L$DIRLIB_MKL -I$MKLINCLUDE -l${baselib} -lmkl_intel_thread -lmkl_core -liomp5 -lpthread"
 
 echo "$LIBG_MKL"
 

--- a/fem3d/simsys_pard.f
+++ b/fem3d/simsys_pard.f
@@ -42,14 +42,14 @@ c******************************************************************
 
 	subroutine system_solve_z(n,z)
 
-	use mod_system
+	!use mod_system
 
 	implicit none
 
         integer n
         real z(n)
 
-	call pard_solve_system
+	call pard_solve_system(n,z)
 
 	end
 

--- a/fem3d/simsys_pard.f
+++ b/fem3d/simsys_pard.f
@@ -49,7 +49,7 @@ c******************************************************************
         integer n
         real z(n)
 
-	call pard_solve_system(n,z)
+	call pard_solve_system(n)
 
 	end
 

--- a/fem3d/subpard.f
+++ b/fem3d/subpard.f
@@ -150,6 +150,10 @@ c*************************************************************************
       data nrhs /1/, maxfct /1/, mnum /1/
 
       integer i
+      
+      logical pdefault
+      
+      pdefault = .true.
 
 ! Variables to save
       save pt,iparm
@@ -160,46 +164,51 @@ c*************************************************************************
 
       if (pcall.eq.0) then  !Initialization
 
-         ! Set the input parameters if not using the default values
-         do i = 1, 64
-            iparm(i) = 0
-         end do
-         iparm(1) = 1 ! no solver default
-	 iparm(2) = 3
-         !iparm(2) = 2 ! fill-in reordering from METIS (suggested for symmetric)
-         iparm(4) = precision	!use 0 for direct, else 31,61,91 etc..
-         iparm(5) = 0 ! no user fill-in reducing permutation
-         iparm(6) = 0 ! =0 solution on the first n compoments of x
-         !iparm(7) = -1 ! number of iterative refinement steps (out)
-         iparm(8) = 0 ! max numbers of iterative refinement steps
-         iparm(10) = 13 ! perturbe the pivot elements with 1E-13
-         iparm(11) = 1 ! use nonsymmetric permutation and scaling MPS
-         iparm(12) = 0 ! Solve with transposed or conjugate transposed matrix A
-         iparm(13) = 1 ! improved accuracy using nonsymmetric matchings
-         !iparm(14) = 0 ! number of perturbed pivots (out)
-         !iparm(15) = 0 ! Peak memory on symbolic factorization (out)
-         !iparm(16) = 0 ! Permanent  memory on symbolic factorization (out)
-         !iparm(17) = 0 ! As 15 added with solution (out)
-         iparm(18) = -1 ! Report the number of nonzeros in the factor LU (in/out)
-         iparm(19) = 0 ! Report Mflops that are necessary to factor the matrix A (use 0 to speedup)
-         !iparm(20) = 0 ! Numbers of CG Iterations
-         iparm(21) = 1 ! pivoting
-         iparm(24) = 0 ! Parallel factorization control (use 1 with many threads > 8)
-         iparm(25) = 0 ! Parallel forward/backward solve control.
-         iparm(27) = 0 ! Matrix checker
-         iparm(28) = 0 ! Single or double precision of PARDISO (0 = double)
-         iparm(31) = 0 ! Partial solve and computing selected components of the solution vectors
-         iparm(34) = 0 ! Optimal number of OpenMP threads for conditional numerical reproducibility (CNR) mode
-         iparm(35) = 0 ! 1-based/0-based input data indexing (0 = fortran style)
-         iparm(36) = 0 ! Schur complement matrix computation control
-         iparm(56) = 0 ! Diagonal and pivoting control
-         iparm(60) = 0 ! PARDISO mode (2 holds the matrix factors in files)
-         
-         !.. Initiliaze the internal solver memory pointer. This is only
-         !   necessary for the FIRST call of the PARDISO solver.
-         do i = 1, 64
-            pt(i) = 0
-         end do
+        if( pdefault ) then
+            ! Set default values for nonsymmetric matrix
+            call pardisoinit(pt, 11, iparm)
+        else
+            ! Set the input parameters
+            do i = 1, 64
+               iparm(i) = 0
+            end do
+            iparm(1) = 1 ! no solver default
+	    iparm(2) = 3
+            !iparm(2) = 2 ! fill-in reordering from METIS (suggested for symmetric)
+            iparm(4) = precision	!use 0 for direct, else 31,61,91 etc..
+            iparm(5) = 0 ! no user fill-in reducing permutation
+            iparm(6) = 0 ! =0 solution on the first n compoments of x
+            !iparm(7) = -1 ! number of iterative refinement steps (out)
+            iparm(8) = 0 ! max numbers of iterative refinement steps
+            iparm(10) = 13 ! perturbe the pivot elements with 1E-13
+            iparm(11) = 1 ! use nonsymmetric permutation and scaling MPS
+            iparm(12) = 0 ! Solve with transposed or conjugate transposed matrix A
+            iparm(13) = 1 ! improved accuracy using nonsymmetric matchings
+            !iparm(14) = 0 ! number of perturbed pivots (out)
+            !iparm(15) = 0 ! Peak memory on symbolic factorization (out)
+            !iparm(16) = 0 ! Permanent  memory on symbolic factorization (out)
+            !iparm(17) = 0 ! As 15 added with solution (out)
+            iparm(18) = -1 ! Report the number of nonzeros in the factor LU (in/out)
+            iparm(19) = 0 ! Report Mflops that are necessary to factor the matrix A (use 0 to speedup)
+            !iparm(20) = 0 ! Numbers of CG Iterations
+            iparm(21) = 1 ! pivoting
+            iparm(24) = 0 ! Parallel factorization control (use 1 with many threads > 8)
+            iparm(25) = 0 ! Parallel forward/backward solve control.
+            iparm(27) = 0 ! Matrix checker
+            iparm(28) = 0 ! Single or double precision of PARDISO (0 = double)
+            iparm(31) = 0 ! Partial solve and computing selected components of the solution vectors
+            iparm(34) = 0 ! Optimal number of OpenMP threads for conditional numerical reproducibility (CNR) mode
+            iparm(35) = 0 ! 1-based/0-based input data indexing (0 = fortran style)
+            iparm(36) = 0 ! Schur complement matrix computation control
+            iparm(56) = 0 ! Diagonal and pivoting control
+            iparm(60) = 0 ! PARDISO mode (2 holds the matrix factors in files)
+            
+            !Initiliaze the internal solver memory pointer.
+            do i = 1, 64
+               pt(i) = 0
+            end do
+            
+        end if
 
          phase = 11 
          call pardiso (pt,maxfct,mnum,mtype,phase,nrow,aa,iaa,jaa,

--- a/fem3d/subpard.f
+++ b/fem3d/subpard.f
@@ -160,38 +160,41 @@ c*************************************************************************
 
       if (pcall.eq.0) then  !Initialization
 
+         ! Set the input parameters if not using the default values
          do i = 1, 64
             iparm(i) = 0
          end do
          iparm(1) = 1 ! no solver default
-	 iparm(2) = 0
-	 if( precision .gt. 0 ) iparm(2) = 2
+	 iparm(2) = 3
          !iparm(2) = 2 ! fill-in reordering from METIS (suggested for symmetric)
-	 !call mkl_set_num_threads(1)
-	 !call omp_set_num_threads(1)
-	 iparm(3)= 0
-!$	 iparm(3)= omp_get_max_threads() !OMP_NUM_THREADS envirom. var.
          iparm(4) = precision	!use 0 for direct, else 31,61,91 etc..
          iparm(5) = 0 ! no user fill-in reducing permutation
          iparm(6) = 0 ! =0 solution on the first n compoments of x
-         iparm(7) = -1 ! number of iterative refinement steps
+         !iparm(7) = -1 ! number of iterative refinement steps (out)
          iparm(8) = 0 ! max numbers of iterative refinement steps
-         iparm(9) = 0 ! not in use
          iparm(10) = 13 ! perturbe the pivot elements with 1E-13
          iparm(11) = 1 ! use nonsymmetric permutation and scaling MPS
-         iparm(12) = 0 ! not in use
+         iparm(12) = 0 ! Solve with transposed or conjugate transposed matrix A
          iparm(13) = 1 ! improved accuracy using nonsymmetric matchings
-         iparm(14) = 0 ! Output: number of perturbed pivots
-         iparm(15) = 0 ! not in use
-         iparm(16) = 0 ! not in use
-         iparm(17) = 0 ! not in use
-         iparm(18) = -1 ! Output: number of nonzeros in the factor LU
-         iparm(19) = -1 ! Output: Mflops for LU factorization
-         iparm(20) = 0 ! Output: Numbers of CG Iterations
+         !iparm(14) = 0 ! number of perturbed pivots (out)
+         !iparm(15) = 0 ! Peak memory on symbolic factorization (out)
+         !iparm(16) = 0 ! Permanent  memory on symbolic factorization (out)
+         !iparm(17) = 0 ! As 15 added with solution (out)
+         iparm(18) = -1 ! Report the number of nonzeros in the factor LU (in/out)
+         iparm(19) = 0 ! Report Mflops that are necessary to factor the matrix A (use 0 to speedup)
+         !iparm(20) = 0 ! Numbers of CG Iterations
          iparm(21) = 1 ! pivoting
-         !iparm(23) = 1 ! 
-         !iparm(24) = 1 ! 
-
+         iparm(24) = 0 ! Parallel factorization control (use 1 with many threads > 8)
+         iparm(25) = 0 ! Parallel forward/backward solve control.
+         iparm(27) = 0 ! Matrix checker
+         iparm(28) = 0 ! Single or double precision of PARDISO (0 = double)
+         iparm(31) = 0 ! Partial solve and computing selected components of the solution vectors
+         iparm(34) = 0 ! Optimal number of OpenMP threads for conditional numerical reproducibility (CNR) mode
+         iparm(35) = 0 ! 1-based/0-based input data indexing (0 = fortran style)
+         iparm(36) = 0 ! Schur complement matrix computation control
+         iparm(56) = 0 ! Diagonal and pivoting control
+         iparm(60) = 0 ! PARDISO mode (2 holds the matrix factors in files)
+         
          !.. Initiliaze the internal solver memory pointer. This is only
          !   necessary for the FIRST call of the PARDISO solver.
          do i = 1, 64

--- a/fem3d/subpard.f
+++ b/fem3d/subpard.f
@@ -52,7 +52,7 @@ c*************************************************************************
         real*8 csr(csrdim)
         integer icsr(n+1),jcsr(csrdim)
 	integer iwork(2*csrdim)		!aux for sorting routine
-        real*8 ddum
+        real*8 ddum(n)
         !integer indu(n),iwk(n+1) !clean-csr vectors
 
 	integer precision
@@ -129,7 +129,6 @@ c*************************************************************************
 ! Solve matrix with pardiso routines
 
 !$      use omp_lib
-      use omp_lib
       implicit none
 !      external pardiso
 
@@ -172,7 +171,8 @@ c*************************************************************************
          !iparm(3) = 2 ! numbers of processors
 	 !call mkl_set_num_threads(1)
 	 !call omp_set_num_threads(1)
-	 iparm(3)= omp_get_max_threads() !OMP_NUM_THREADS envirom. var.
+	 iparm(3)= 0
+!$	 iparm(3)= omp_get_max_threads() !OMP_NUM_THREADS envirom. var.
          iparm(4) = precision	!use 0 for direct, else 31,61,91 etc..
          iparm(5) = 0 ! no user fill-in reducing permutation
          iparm(6) = 0 ! =0 solution on the first n compoments of x

--- a/fem3d/subpard.f
+++ b/fem3d/subpard.f
@@ -148,16 +148,15 @@ c*************************************************************************
       integer perm(nrow) !permutation vector or specifies elements used 
                          !for computing a partial solution
       data nrhs /1/, maxfct /1/, mnum /1/
-
       integer i
+      
+! Variables to save
+      save pt,iparm
       
       logical pdefault
       
       pdefault = .true.
-
-! Variables to save
-      save pt,iparm
-
+      
       mtype = 11 ! real unsymmetric
       error = 0 ! initialize error flag
       msglvl = 0 ! print statistical information
@@ -173,7 +172,7 @@ c*************************************************************************
                iparm(i) = 0
             end do
             iparm(1) = 1 ! no solver default
-	    iparm(2) = 3
+            iparm(2) = 3
             !iparm(2) = 2 ! fill-in reordering from METIS (suggested for symmetric)
             iparm(4) = precision	!use 0 for direct, else 31,61,91 etc..
             iparm(5) = 0 ! no user fill-in reducing permutation

--- a/fem3d/subpard.f
+++ b/fem3d/subpard.f
@@ -6,6 +6,7 @@ c*************************************************************************
 ! Initialize vector and matrix      
 
 	use mod_system
+        use basin
 
       implicit none
       include 'param.h'
@@ -36,19 +37,23 @@ c*************************************************************************
 
 c*************************************************************************
 
-	subroutine pard_solve_system
+	subroutine pard_solve_system(n,z)
 
 	use mod_system
 
 	implicit none
+
+        integer n
+        real z(n) !first guess
+
         include 'param.h'
 	integer k
 
         real*8 csr(csrdim)
-        integer icsr(nkn+1),jcsr(csrdim)
+        integer icsr(n+1),jcsr(csrdim)
 	integer iwork(2*csrdim)		!aux for sorting routine
         real*8 ddum
-        !integer indu(nkn),iwk(nkn+1) !clean-csr vectors
+        !integer indu(n),iwk(n+1) !clean-csr vectors
 
 	integer precision
 	logical bdirect		!iterative solver
@@ -56,6 +61,10 @@ c*************************************************************************
         integer icall
         data icall /0/
         save icall
+
+        integer nkn
+
+        nkn = n
 
 	precision = iprec	!precision - see common.h
 
@@ -119,6 +128,7 @@ c*************************************************************************
 
 ! Solve matrix with pardiso routines
 
+!$      use omp_lib
       use omp_lib
       implicit none
 !      external pardiso

--- a/femadj/Makefile
+++ b/femadj/Makefile
@@ -136,24 +136,23 @@ strip:
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-adj4el.o: param.h ../femlib/mod/basin.mod \
+adj4el.o: ../femlib/mod/mod_adj_grade.mod param.h \
+		../femlib/mod/basin.mod 
+adj575.o: ../femlib/mod/basin.mod param.h \
 		../femlib/mod/mod_adj_grade.mod 
-adj575.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_adj_grade.mod 
-adj5el.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_adj_grade.mod 
+adj5el.o: ../femlib/mod/mod_adj_grade.mod param.h \
+		../femlib/mod/basin.mod 
 adj7el.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_adj_grade.mod 
-adjele.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_adj_grade.mod 
+adjele.o: ../femlib/mod/mod_depth.mod ../femlib/mod/basin.mod \
+		param.h ../femlib/mod/mod_adj_grade.mod 
 adjgrd.o: nbstatic.h
-adjneu.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_adj_grade.mod 
-adjplo.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/mod_adj_grade.mod 
-adjvar.o: param.h ../femlib/mod/basin.mod nbstatic.h \
-		../femlib/mod/mod_adj_grade.mod 
+adjneu.o: ../femlib/mod/basin.mod param.h \
+		../femlib/mod/mod_adj_grade.mod \
+		../femlib/mod/mod_depth.mod 
+adjplo.o: ../femlib/mod/mod_adj_grade.mod ../femlib/mod/basin.mod \
+		param.h 
+adjvar.o: ../femlib/mod/mod_adj_grade.mod param.h \
+		../femlib/mod/basin.mod nbstatic.h 
 ../femlib/mod/mod_adj_grade.mod: mod_adj_grade.o
 

--- a/femplot/Makefile
+++ b/femplot/Makefile
@@ -178,72 +178,69 @@ strip:	$(EXES)
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 col.o: color.h
-lagxitest.o: param.h ../femlib/mod/basin.mod \
+lagxitest.o: ../femlib/mod/basin.mod param.h \
 		../femlib/mod/evgeom.mod 
 line_nodes.o: param.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_geom.mod 
 ../femlib/mod/mod_hydro_plot.mod: mod_hydro_plot.o
 ../femlib/mod/mod_plot2d.mod: mod_plot2d.o
 ../femlib/mod/mod_plot3d.mod: mod_plot3d.o
-plotsim.o: param.h ../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod mkonst.h \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_plot3d.mod pkonst.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_plot2d.mod \
+plotsim.o: ../femlib/mod/mod_hydro_vel.mod \
 		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_geom.mod pkonst.h \
+		../femlib/mod/mod_plot2d.mod \
 		../femlib/mod/mod_hydro_plot.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
-supano.o: color.h param.h ../femlib/mod/basin.mod legend.h simul.h
-supbas.o: param.h ../femlib/mod/basin.mod supout.h \
-		../femlib/mod/mod_geom.mod 
+		../femlib/mod/mod_plot3d.mod \
+		../femlib/mod/mod_hydro.mod mkonst.h \
+		../femlib/mod/evgeom.mod ../femlib/mod/levels.mod \
+		param.h 
+supano.o: param.h legend.h color.h ../femlib/mod/basin.mod simul.h
+supbas.o: ../femlib/mod/basin.mod ../femlib/mod/mod_geom.mod \
+		supout.h param.h 
 supcol.o: color.h
-supdep.o: ../femlib/mod/levels.mod param.h \
-		../femlib/mod/mod_depth.mod \
+supdep.o: ../femlib/mod/mod_hydro.mod ../femlib/mod/evgeom.mod \
+		../femlib/mod/levels.mod param.h \
 		../femlib/mod/basin.mod \
 		../femlib/mod/mod_plot2d.mod \
-		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/evgeom.mod 
-supint.o: param.h ../femlib/mod/levels.mod
-supiso.o: color.h param.h ../femlib/mod/basin.mod
-suplag.o: color.h param.h ../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod 
+supint.o: ../femlib/mod/levels.mod param.h
+supiso.o: ../femlib/mod/basin.mod color.h param.h
+suplag.o: param.h color.h ../femlib/mod/basin.mod \
 		../femlib/mod/mod_plot2d.mod 
-suplin.o: color.h param.h ../femlib/mod/levels.mod \
+suplin.o: param.h ../femlib/mod/levels.mod \
 		../femlib/mod/mod_depth.mod \
-		../femlib/mod/basin.mod \
+		../femlib/mod/basin.mod color.h \
 		../femlib/mod/mod_hydro_print.mod 
-suplin1.o: param.h ../femlib/mod/basin.mod \
-		../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_plot3d.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/mod_plot2d.mod \
-		../femlib/mod/mod_hydro_print.mod \
-		../femlib/mod/mod_hydro.mod 
-supout.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_plot3d.mod simul.h \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_plot2d.mod \
-		../femlib/mod/mod_hydro_print.mod \
+suplin1.o: ../femlib/mod/mod_plot2d.mod ../femlib/mod/levels.mod \
+		param.h ../femlib/mod/mod_plot3d.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_hydro_plot.mod supout.h 
-supsim.o: ../femlib/mod/mod_depth.mod param.h \
-		../femlib/mod/basin.mod \
-		../femlib/mod/mod_plot3d.mod \
+		../femlib/mod/evgeom.mod \
 		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
-		../femlib/mod/mod_plot2d.mod \
+		../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/basin.mod 
+supout.o: ../femlib/mod/mod_hydro_print.mod \
+		../femlib/mod/basin.mod \
+		../femlib/mod/mod_depth.mod supout.h \
+		../femlib/mod/mod_plot2d.mod simul.h \
+		../femlib/mod/mod_plot3d.mod \
 		../femlib/mod/mod_hydro_plot.mod \
 		../femlib/mod/mod_hydro.mod \
-		../femlib/mod/mod_geom.mod 
-suptim.o: timlim.h
-supver.o: param.h ../femlib/mod/basin.mod ../femlib/mod/evgeom.mod \
-		../femlib/mod/mod_plot3d.mod \
-		../femlib/mod/mod_hydro_vel.mod \
-		../femlib/mod/levels.mod \
+		../femlib/mod/levels.mod param.h 
+supsim.o: ../femlib/mod/basin.mod ../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/mod_depth.mod \
+		../femlib/mod/mod_geom.mod \
 		../femlib/mod/mod_plot2d.mod \
-		../femlib/mod/mod_hydro.mod 
+		../femlib/mod/mod_hydro_plot.mod \
+		../femlib/mod/mod_plot3d.mod \
+		../femlib/mod/mod_hydro.mod param.h \
+		../femlib/mod/levels.mod 
+suptim.o: timlim.h
+supver.o: ../femlib/mod/mod_plot2d.mod ../femlib/mod/levels.mod \
+		param.h ../femlib/mod/mod_hydro.mod \
+		../femlib/mod/mod_plot3d.mod \
+		../femlib/mod/evgeom.mod \
+		../femlib/mod/mod_hydro_vel.mod \
+		../femlib/mod/basin.mod 
 

--- a/grid/Makefile
+++ b/grid/Makefile
@@ -205,62 +205,63 @@ list:
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-gridma1.o: grid_ex.h gridky.h grid_df.h screen.h grid_fp.h keybd.h \
-		list.h mouse.h graph.h queue.h gustd.h hash.h \
-		gridhs.h grid_ty.h fund.h events.h grid.h menu.h \
-		general.h 
-gridma2.o: grid_ex.h gridky.h grid_df.h screen.h grid_fp.h keybd.h \
-		list.h mouse.h graph.h queue.h gustd.h hash.h \
-		gridhs.h grid_ty.h fund.h gridnl.h grid.h menu.h \
-		general.h 
-gridfi.o: grid_ex.h grid_df.h screen.h grid_fp.h keybd.h list.h \
-		psgraph.h queue.h gustd.h hash.h gridhs.h \
-		grid_ty.h fund.h grid.h general.h menu.h args.h 
-gridge.o: grid_ex.h gustd.h queue.h gridhs.h hash.h grid_df.h \
-		screen.h grid_ty.h grid_fp.h fund.h list.h grid.h \
-		general.h menu.h 
-gridhs.o: grid_ex.h queue.h grid_df.h hash.h gridhs.h grid_ty.h \
-		fund.h gridnl.h list.h keybd.h general.h 
-gridlo.o: grid_ex.h grid_df.h screen.h grid_fp.h keybd.h list.h \
-		mouse.h graph.h queue.h gustd.h hash.h gridhs.h \
-		grid_ty.h fund.h events.h grid.h menu.h general.h 
-gridop.o: grid_ex.h xgraph.h grid_df.h screen.h grid_fp.h list.h \
-		generalx.h graph.h queue.h gustd.h hash.h gridhs.h \
-		grid_ty.h fund.h grid.h general.h menu.h 
-gridpl.o: graph.h grid_ex.h queue.h gridhs.h hash.h grid_df.h \
-		screen.h grid_ty.h grid_fp.h fund.h list.h mouse.h \
-		grid.h general.h menu.h 
-gridut.o: grid_ex.h queue.h gridhs.h hash.h grid_df.h screen.h \
-		grid_ty.h grid_fp.h fund.h list.h grid.h general.h \
-		menu.h 
-gridwi.o: graph.h grid_ex.h queue.h gridhs.h hash.h grid_df.h \
-		screen.h grid_ty.h grid_fp.h fund.h list.h mouse.h \
-		grid.h general.h menu.h 
-gridps.o: grid_ex.h grid_df.h screen.h grid_fp.h keybd.h list.h \
-		psgraph.h queue.h gustd.h hash.h gridhs.h \
-		grid_ty.h fund.h grid.h general.h menu.h args.h 
-gridky.o: graph.h grid_ex.h gustd.h queue.h gridhs.h hash.h \
-		grid_df.h screen.h grid_ty.h grid_fp.h fund.h \
-		list.h grid.h general.h menu.h 
-gridco.o: color.h grid_ex.h grid_df.h screen.h grid_fp.h list.h \
-		graph.h queue.h gustd.h hash.h gridhs.h grid_ty.h \
-		fund.h grid.h general.h menu.h 
-gridnl.o: fund.h gridnl.h list.h general.h
-menu.o: stack.h graph.h assert.h screen.h events.h mouse.h \
-		general.h menu.h 
+gridma1.o: graph.h general.h menu.h grid.h list.h grid_fp.h \
+		gridky.h queue.h screen.h gustd.h fund.h grid_ex.h \
+		grid_df.h mouse.h hash.h gridhs.h events.h keybd.h \
+		grid_ty.h 
+gridma2.o: screen.h gustd.h fund.h gridky.h queue.h list.h \
+		grid_fp.h grid.h menu.h general.h graph.h keybd.h \
+		grid_ty.h gridhs.h hash.h mouse.h gridnl.h \
+		grid_df.h grid_ex.h 
+gridfi.o: list.h grid_fp.h psgraph.h grid.h gustd.h fund.h \
+		screen.h queue.h args.h menu.h general.h hash.h \
+		grid_ty.h keybd.h gridhs.h grid_ex.h grid_df.h 
+gridge.o: grid_ex.h grid_df.h general.h menu.h grid.h hash.h \
+		grid_fp.h list.h gridhs.h queue.h screen.h gustd.h \
+		grid_ty.h fund.h 
+gridhs.o: list.h hash.h grid_ty.h fund.h keybd.h queue.h gridhs.h \
+		grid_ex.h grid_df.h general.h gridnl.h 
+gridlo.o: menu.h general.h graph.h screen.h gustd.h fund.h queue.h \
+		grid_fp.h list.h grid.h mouse.h grid_df.h \
+		grid_ex.h keybd.h grid_ty.h gridhs.h events.h \
+		hash.h 
+gridop.o: generalx.h xgraph.h hash.h gridhs.h grid_ty.h grid_ex.h \
+		grid_df.h grid.h grid_fp.h list.h queue.h screen.h \
+		gustd.h fund.h graph.h general.h menu.h 
+gridpl.o: grid.h hash.h grid_fp.h list.h gridhs.h queue.h screen.h \
+		fund.h grid_ty.h graph.h grid_ex.h general.h \
+		grid_df.h menu.h mouse.h 
+gridut.o: fund.h grid_ty.h screen.h queue.h gridhs.h list.h \
+		grid_fp.h hash.h grid.h menu.h general.h grid_df.h \
+		grid_ex.h 
+gridwi.o: list.h grid_fp.h hash.h grid.h grid_ty.h fund.h screen.h \
+		queue.h gridhs.h graph.h grid_ex.h menu.h mouse.h \
+		grid_df.h general.h 
+gridps.o: args.h queue.h screen.h gustd.h fund.h grid.h psgraph.h \
+		list.h grid_fp.h general.h menu.h gridhs.h keybd.h \
+		grid_ty.h hash.h grid_df.h grid_ex.h 
+gridky.o: grid_ex.h graph.h menu.h general.h grid_df.h hash.h \
+		list.h grid_fp.h grid.h screen.h grid_ty.h gustd.h \
+		fund.h gridhs.h queue.h 
+gridco.o: color.h grid_ex.h grid_df.h hash.h gridhs.h grid_ty.h \
+		graph.h general.h menu.h grid.h list.h grid_fp.h \
+		queue.h fund.h gustd.h screen.h 
+gridnl.o: general.h gridnl.h fund.h list.h
+menu.o: graph.h assert.h menu.h stack.h mouse.h general.h screen.h \
+		events.h 
 stack.o: stack.h general.h
 screen.o: graph.h general.h
 general.o: general.h
-gustd.o: gustd.h general.h
-debug.o: debug.h general.h
-color.o: graph.h general.h
+gustd.o: general.h gustd.h
+debug.o: general.h debug.h
+color.o: general.h graph.h
 hash.o: hash.h general.h
-list.o: list.h general.h
+list.o: general.h list.h
 args.o: general.h
 queue.o: queue.h general.h
-psgraph.o: psgraph.h gustd.h general.h
+psgraph.o: psgraph.h general.h gustd.h
 xmouse.o: mouse.h
-xgraph.o: graph.h xgraph.h generalx.h general.h
-xevents.o: debug.h events.h xgraph.h general.h generalx.h
+xgraph.o: general.h generalx.h graph.h xgraph.h
+xevents.o: general.h events.h xgraph.h debug.h generalx.h
 xkeybd.o: keybd.h general.h
 

--- a/hcbs/Makefile
+++ b/hcbs/Makefile
@@ -111,7 +111,7 @@ zip: cleanall
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 general.o: general.h
-gustd.o: gustd.h general.h
-xgraph.o: graph.h xgraph.h generalx.h general.h
-xgraphf.o: graph.h gustd.h xgraph.h generalx.h general.h
+gustd.o: general.h gustd.h
+xgraph.o: xgraph.h general.h generalx.h graph.h
+xgraphf.o: gustd.h graph.h generalx.h xgraph.h general.h
 

--- a/mesh/Makefile
+++ b/mesh/Makefile
@@ -174,60 +174,59 @@ list:
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-mesh.o: mesh.h meshin.h meshfi.h meshge.h list.h meshbd.h meshut.h \
-		meshty.h stack.h meshcv.h gustd.h queue.h meshop.h \
-		meshck.h hash.h fund.h heap.h nlist.h meshhs.h \
+mesh.o: meshge.h meshfi.h gustd.h meshbd.h heap.h meshhs.h mesh.h \
+		meshty.h nlist.h meshcv.h meshck.h meshop.h \
+		meshin.h hash.h list.h meshut.h stack.h fund.h \
+		general.h queue.h 
+exgrd.o: stack.h fund.h grdhs.h gustd.h hash.h exgrdop.h grd.h \
+		queue.h grdut.h grdio.h general.h 
+meshut.o: fund.h meshhs.h meshut.h assert.h heap.h list.h meshge.h \
+		hash.h queue.h general.h nlist.h meshty.h mesh.h 
+meshcv.o: meshut.h stack.h meshhs.h fund.h hash.h list.h heap.h \
+		queue.h mesh.h meshty.h nlist.h meshck.h meshcv.h \
 		general.h 
-exgrd.o: stack.h grdio.h queue.h gustd.h grdut.h hash.h exgrdop.h \
-		fund.h grdhs.h grd.h general.h 
-meshut.o: meshty.h queue.h hash.h mesh.h assert.h heap.h fund.h \
-		nlist.h meshge.h meshhs.h list.h meshut.h \
-		general.h 
-meshcv.o: meshty.h stack.h meshcv.h queue.h meshck.h hash.h mesh.h \
-		heap.h fund.h nlist.h meshhs.h list.h meshut.h \
-		general.h 
-meshfi.o: meshty.h meshgd.h queue.h gustd.h meshop.h hash.h mesh.h \
-		fund.h meshfi.h nlist.h meshhs.h list.h general.h \
-		meshut.h 
-meshck.o: mesh.h meshin.h meshge.h list.h meshut.h stack.h \
-		meshty.h gustd.h queue.h meshck.h meshop.h hash.h \
-		fund.h heap.h nlist.h meshhs.h general.h 
-meshin.o: mesh.h meshin.h meshge.h list.h meshut.h stack.h \
-		meshty.h queue.h meshck.h meshop.h hash.h heap.h \
-		fund.h nlist.h meshhs.h general.h 
-meshbd.o: mesh.h meshin.h meshge.h list.h meshbd.h meshut.h \
-		meshty.h stack.h queue.h meshop.h hash.h fund.h \
-		heap.h nlist.h meshhs.h general.h 
-meshge.o: queue.h gustd.h hash.h mesh.h heap.h fund.h meshfi.h \
-		nlist.h meshhs.h meshge.h list.h general.h 
-meshhs.o: queue.h fund.h list.h hash.h mesh.h
-meshop.o: queue.h gustd.h options.h meshop.h hash.h mesh.h fund.h \
-		list.h general.h 
-meshgd.o: meshgd.h queue.h gustd.h hash.h mesh.h fund.h nlist.h \
-		meshhs.h list.h meshut.h general.h args.h 
-meshty.o: meshty.h assert.h queue.h fund.h hash.h list.h mesh.h \
-		general.h 
+meshfi.o: meshop.h queue.h general.h mesh.h meshty.h nlist.h \
+		fund.h meshut.h meshhs.h list.h hash.h meshfi.h \
+		meshgd.h gustd.h 
+meshck.o: general.h queue.h list.h hash.h fund.h meshut.h stack.h \
+		meshck.h mesh.h meshty.h nlist.h meshin.h meshop.h \
+		heap.h meshge.h gustd.h meshhs.h 
+meshin.o: meshop.h meshin.h nlist.h meshty.h mesh.h meshck.h \
+		meshhs.h meshge.h heap.h queue.h general.h stack.h \
+		meshut.h fund.h hash.h list.h 
+meshbd.o: nlist.h meshty.h mesh.h meshop.h meshin.h meshge.h \
+		heap.h meshbd.h meshhs.h general.h queue.h hash.h \
+		list.h stack.h meshut.h fund.h 
+meshge.o: general.h mesh.h nlist.h queue.h list.h heap.h meshge.h \
+		hash.h meshfi.h gustd.h fund.h meshhs.h 
+meshhs.o: list.h hash.h mesh.h fund.h queue.h
+meshop.o: fund.h list.h hash.h gustd.h options.h meshop.h queue.h \
+		general.h mesh.h 
+meshgd.o: queue.h general.h mesh.h nlist.h fund.h meshut.h \
+		meshhs.h args.h list.h hash.h meshgd.h gustd.h 
+meshty.o: list.h assert.h hash.h fund.h general.h mesh.h meshty.h \
+		queue.h 
 general.o: general.h
 gustd.o: gustd.h general.h
 debug.o: debug.h general.h
-hash.o: hash.h general.h
+hash.o: general.h hash.h
 list.o: list.h general.h
 args.o: general.h
-queue.o: queue.h general.h
+queue.o: general.h queue.h
 heap.o: heap.h general.h
 stack.o: stack.h general.h
-nlist.o: nlist.h general.h
+nlist.o: general.h nlist.h
 assert.o: assert.h
-exgrdop.o: queue.h gustd.h grdut.h options.h hash.h exgrdop.h \
-		fund.h grd.h general.h 
-grdio.o: queue.h gustd.h grdut.h hash.h fund.h grd.h grdhs.h \
-		general.h args.h 
-grdhs.o: queue.h fund.h grd.h hash.h
-grdut.o: queue.h fund.h grdut.h grdhs.h grd.h hash.h general.h
-gustd.o: gustd.h general.h
+exgrdop.o: options.h queue.h grdut.h general.h fund.h grd.h \
+		gustd.h exgrdop.h hash.h 
+grdio.o: general.h grdut.h queue.h hash.h gustd.h args.h grd.h \
+		grdhs.h fund.h 
+grdhs.o: fund.h queue.h grd.h hash.h
+grdut.o: hash.h grd.h general.h queue.h grdut.h grdhs.h fund.h
+gustd.o: general.h gustd.h
 args.o: general.h
-hash.o: hash.h general.h
-queue.o: queue.h general.h
+hash.o: general.h hash.h
+queue.o: general.h queue.h
 stack.o: stack.h general.h
 general.o: general.h
 

--- a/post/Makefile
+++ b/post/Makefile
@@ -167,12 +167,12 @@ save:   cleanall
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 colorutil.o: general.h
-demopost.o: pgraph.h general.h
+demopost.o: general.h pgraph.h
 general.o: general.h
-gustd.o: gustd.h general.h
+gustd.o: general.h gustd.h
 pc.o: pspost.h
 pcalp.o: pgraph.h general.h
 pgraph.o: pgraph.h general.h
-psgraph.o: psgraph.h gustd.h colorutil.h general.h
+psgraph.o: gustd.h general.h psgraph.h colorutil.h
 psgraphf.o: psgraph.h general.h
 


### PR DESCRIPTION
The Intel MKL libraries changed in the last versions. See:
https://software.intel.com/en-us/articles/mkl_solver_libraries_are_deprecated_libraries_since_version_10_2_Update_2
- The links to the new libraries are updated;
- MKL libraries are now dynamically linked (not hard);
- Pardiso routines are updated with the use of modules;
- Pardiso parameters are updated according to the last versions.

Note: do not look at the differences between Makefiles which are automatically changed by 'make depend'
