### PR TITLE
added the possibility to choose among all the water types described in Jerlov (1968)

### DIFF
--- a/fem3d/subsys.f
+++ b/fem3d/subsys.f
@@ -706,6 +706,18 @@ c               (Default 0)
 
         call addpar('isolp',0.)         !type of solar penetration   
 
+c |iwtyp|       The water types from clear water (type I) to the most 
+c               turbid water (coastal water 9) following the classification of
+c               Jerlov (Jerlov, N. G., 1968 Optical Oceanography, 
+c               Elsevier, 194pp).
+c               |iwtyp| = 0 :clear water type I ; |iwtyp| = 1 : type IA
+c               |iwtyp| = 2 : type IB ; |iwtyp| = 3 : type II
+c               |iwtyp| = 4 : type III; |iwtyp| = 5 : type 1
+c               |iwtyp| = 6 : type 3  ; |iwtyp| = 7 : type 5
+c               |iwtyp| = 8 : type 7  ; |iwtyp| = 9 : type 9
+
+        call addpar('iwtyp',0.)         !water type (works if |isolp|=1)
+
 c |hdecay|	Depth of e-folding decay of radiation [m]. If |hdecay| = 0 
 c		everything is absorbed in first layer (Default 0).
 


### PR DESCRIPTION
added the possibility to choose among all the water types described 
in Jerlov (1968) using a new parameter |iwtyp|.
Coefficient for water types I,IA,IB,II,III and IV
are taken from Paul e Simpson (1977). coefficient for coastal water
1, 3, 5, 7 and 9 are computed fitting data from table XXI of Jerlov (1968)