### PR TITLE
Redundant variables cause compilation fail

### DIFF
--- a/fem3d/newbfm.f
+++ b/fem3d/newbfm.f
@@ -234,8 +234,8 @@ c-------------------------------------------------------------
 
 	do i=1,nvar
 
-!$OMP TASK FIRSTPRIVATE(i,rkpar,wsink,difhv,difv,difmol,idbfm,what,
-!$OMP&     dt,nlvdi) SHARED(bfmv)  DEFAULT(NONE)
+!$OMP TASK FIRSTPRIVATE(i,rkpar,wsink,difhv,difv,difmol,idbfm,what)
+!$OMP&     SHARED(bfmv)  DEFAULT(NONE)
  
 ! use scal_adv_fact to pass wsink matrix into advection
 


### PR DESCRIPTION
When openmp flag is on dt variable which is not defined causes the compilation to fail. Since the last two variables, dt and nlvdi are redundant in the loop, they can be removed and the issue is fixed.